### PR TITLE
Implemented `is_function` and related traits for libstdc++

### DIFF
--- a/include/slb/detail/lib.hpp
+++ b/include/slb/detail/lib.hpp
@@ -20,6 +20,21 @@ namespace lib {
 template <typename>
 struct always_false : std::false_type {};
 
+////////////////////////////////////////////////////////////////////////////////
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4180) // qualifier applied to function type has no
+                                // meaning; ignored
+#endif
+template <typename T>
+struct is_function : std::integral_constant<bool,
+                                            !std::is_const<T const>::value &&
+                                                !std::is_reference<T>::value> {
+};
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 } // namespace lib
 } // namespace detail
 } // namespace slb

--- a/test/type_traits.cpp
+++ b/test/type_traits.cpp
@@ -152,6 +152,12 @@ TEST_CASE("is_member_object_pointer", "[meta.unary.cat]") {
   class C {};
   CHECK(std::is_base_of<slb::true_type,
                         slb::is_member_object_pointer<int C::*>>::value);
+
+  CHECK(std::is_base_of<slb::false_type,
+                        slb::is_member_object_pointer<int (C::*)()>>::value);
+  CHECK(std::is_base_of<
+        slb::false_type,
+        slb::is_member_object_pointer<int (C::*)() noexcept>>::value);
 }
 
 // template<class T> struct is_member_function_pointer;
@@ -159,6 +165,12 @@ TEST_CASE("is_member_function_pointer", "[meta.unary.cat]") {
   class C {};
   CHECK(std::is_base_of<slb::true_type,
                         slb::is_member_function_pointer<int (C::*)()>>::value);
+  CHECK(std::is_base_of<
+        slb::true_type,
+        slb::is_member_function_pointer<int (C::*)() noexcept>>::value);
+
+  CHECK(std::is_base_of<slb::false_type,
+                        slb::is_member_function_pointer<int C::*>>::value);
 }
 
 // template<class T> struct is_enum;
@@ -182,6 +194,15 @@ TEST_CASE("is_class", "[meta.unary.cat]") {
 // template<class T> struct is_function;
 TEST_CASE("is_function", "[meta.unary.cat]") {
   CHECK(std::is_base_of<slb::true_type, slb::is_function<void()>>::value);
+  CHECK(std::is_base_of<slb::true_type,
+                        slb::is_function<void() noexcept>>::value);
+
+  CHECK(std::is_base_of<slb::true_type, slb::is_function<void(...)>>::value);
+  CHECK(std::is_base_of<slb::true_type,
+                        slb::is_function<void(...) noexcept>>::value);
+
+  CHECK(std::is_base_of<slb::false_type, slb::is_function<int const>>::value);
+  CHECK(std::is_base_of<slb::false_type, slb::is_function<int&>>::value);
 }
 
 // template<class T> struct is_null_pointer;
@@ -219,6 +240,10 @@ TEST_CASE("is_fundamental", "[meta.unary.comp]") {
 // template<class T> struct is_object;
 TEST_CASE("is_object", "[meta.unary.comp]") {
   CHECK(std::is_base_of<slb::true_type, slb::is_object<int>>::value);
+
+  CHECK(std::is_base_of<slb::false_type, slb::is_object<void()>>::value);
+  CHECK(
+      std::is_base_of<slb::false_type, slb::is_object<void() noexcept>>::value);
 }
 
 // template<class T> struct is_scalar;


### PR DESCRIPTION
Work around for libstdc++ failing to classify function types with noexcept specifiers