### PR TITLE
Implemented <string_view>

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,10 @@
   - `mem_fn`
   - `not_fn`
 
+#### `<string_view>`
+
+  - `string_view`
+
 #### `<type_traits>`
 
   - `bool_constant`
@@ -316,7 +320,7 @@
   - [ ] [P0394](https://wg21.link/P0394): Hotel Parallelifornia: `terminate()` for Parallel Algorithms Exception Handling
   - [ ] [P0003](https://wg21.link/P0003): Removing Deprecated Exception Specifications from C++17
   - [ ] [P0067](https://wg21.link/P0067): Elementary string conversions, revision 5
-  - [ ] [P0403](https://wg21.link/P0403): Literal suffixes for `basic_string_view`
+  - [X] [P0403](https://wg21.link/P0403): Literal suffixes for `basic_string_view`
   - [ ] [P0414](https://wg21.link/P0414): Merging `shared_ptr` changes from Library Fundamentals to C++17
   - [ ] [P0418](https://wg21.link/P0418): Fail or succeed: there is no atomic lattice
   - [ ] [P0426](https://wg21.link/P0426): Constexpr for `std::char_traits`
@@ -579,7 +583,7 @@
   - [ ] [LWG2748](https://wg21.link/LWG2748): `swappable` traits for optionals
   - [ ] [LWG2749](https://wg21.link/LWG2749): `swappable` traits for variants
   - [ ] [LWG2752](https://wg21.link/LWG2752): "Throws:" clauses of `async` and `packaged_task` are unimplementable
-  - [ ] [LWG2755](https://wg21.link/LWG2755): [string.view.io] uses non-existent `basic_string_view::to_string` function
+  - [X] [LWG2755](https://wg21.link/LWG2755): [string.view.io] uses non-existent `basic_string_view::to_string` function
   - [ ] [LWG2756](https://wg21.link/LWG2756): C++ WP optional should `forward` `T`'s implicit conversions
   - [ ] [LWG2758](https://wg21.link/LWG2758): `std::string{}.assign("ABCDE", 0, 1)` is ambiguous
   - [ ] [LWG2759](https://wg21.link/LWG2759): `gcd` / `lcm` and `bool` for the WP
@@ -589,8 +593,8 @@
   - [ ] [LWG2769](https://wg21.link/LWG2769): Redundant const in the return type of `any_cast(const any&)`
   - [ ] [LWG2771](https://wg21.link/LWG2771): Broken _Effects_ of some `basic_string::compare` functions in terms of `basic_string_view`
   - [ ] [LWG2773](https://wg21.link/LWG2773): Making `std::ignore` constexpr
-  - [ ] [LWG2777](https://wg21.link/LWG2777): `basic_string_view::copy` should use `char_traits::copy`
-  - [ ] [LWG2778](https://wg21.link/LWG2778): `basic_string_view` is missing `constexpr`
+  - [X] [LWG2777](https://wg21.link/LWG2777): `basic_string_view::copy` should use `char_traits::copy`
+  - [X] [LWG2778](https://wg21.link/LWG2778): `basic_string_view` is missing `constexpr`
   - [ ] [LWG2260](https://wg21.link/LWG2260): Missing requirement for `Allocator::pointer`
   - [ ] [LWG2676](https://wg21.link/LWG2676): Provide `filesystem::path` overloads for File-based streams
   - [ ] [LWG2768](https://wg21.link/LWG2768): `any_cast` and move semantics
@@ -614,7 +618,7 @@
   - [X] [LWG2807](https://wg21.link/LWG2807): `std::invoke` should use `std::is_nothrow_callable`
   - [ ] [LWG2812](https://wg21.link/LWG2812): Range access is available with `<string_view>`
   - [ ] [LWG2824](https://wg21.link/LWG2824): `list::sort` should say that the order of elements is unspecified if an exception is thrown
-  - [ ] [LWG2826](https://wg21.link/LWG2826): `string_view` iterators use old wording
+  - [X] [LWG2826](https://wg21.link/LWG2826): `string_view` iterators use old wording
   - [ ] [LWG2834](https://wg21.link/LWG2834): Resolution LWG 2223 is missing wording about end iterators
   - [ ] [LWG2835](https://wg21.link/LWG2835): LWG 2536 seems to misspecify `<tgmath.h>`
   - [ ] [LWG2837](https://wg21.link/LWG2837): `gcd` and `lcm` should support a wider range of input values

--- a/include/slb/detail/config.hpp
+++ b/include/slb/detail/config.hpp
@@ -27,6 +27,14 @@
 #define __has_feature(x) 0
 #endif
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
+
 #ifndef __has_warning
 #define __has_warning(x) 0
 #endif
@@ -47,6 +55,15 @@
 #define SLB_HAS_CXX14_VARIABLE_TEMPLATES 1
 #else
 #define SLB_HAS_CXX14_VARIABLE_TEMPLATES 0
+#endif
+
+// P0189: "Wording for [[nodiscard]] attribute"
+#if __has_cpp_attribute(nodiscard) > 201603
+#define SLB_CXX17_NODISCARD [[nodiscard]]
+#elif __has_attribute(warn_unused_result)
+#define SLB_CXX17_NODISCARD __attribute__((warn_unused_result))
+#else
+#define SLB_CXX17_NODISCARD
 #endif
 
 // P0386: "Inline Variables"

--- a/include/slb/detail/lib.hpp
+++ b/include/slb/detail/lib.hpp
@@ -37,6 +37,25 @@ struct is_function : std::integral_constant<bool,
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename T>
+constexpr T(min)(T a, T b) {
+  return a < b ? a : b;
+}
+template <typename T, typename... Ts>
+constexpr T(min)(T a, T b, Ts... cs) {
+  return (min)((min)(a, b), cs...);
+}
+
+template <typename T>
+constexpr T(max)(T a, T b) {
+  return a < b ? b : a;
+}
+template <typename T, typename... Ts>
+constexpr T(max)(T a, T b, Ts... cs) {
+  return (max)((max)(a, b), cs...);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template <typename T>
 struct remove_cvref {
   using type =
       typename std::remove_cv<typename std::remove_reference<T>::type>::type;

--- a/include/slb/string_view.hpp
+++ b/include/slb/string_view.hpp
@@ -1,0 +1,941 @@
+﻿/*
+  SLB.String_View
+
+  Copyright Michael Park, 2017
+  Copyright Agustin Berge, 2017
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef SLB_STRING_VIEW_HPP
+#define SLB_STRING_VIEW_HPP
+
+/*
+
+Header <string_view> synopsis [string.view.synop]
+
+namespace std {
+  // [string.view.template], class template basic_string_view
+  template<class charT, class traits = char_traits<charT>>
+  class basic_string_view;
+
+  // [string.view.comparison], non-member comparison functions
+  template<class charT, class traits>
+    constexpr bool operator==(basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  template<class charT, class traits>
+    constexpr bool operator!=(basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  template<class charT, class traits>
+    constexpr bool operator< (basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  template<class charT, class traits>
+    constexpr bool operator> (basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  template<class charT, class traits>
+    constexpr bool operator<=(basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  template<class charT, class traits>
+    constexpr bool operator>=(basic_string_view<charT, traits> x,
+                              basic_string_view<charT, traits> y) noexcept;
+  // see [string.view.comparison], sufficient additional overloads of comparison
+  // functions
+
+  // [string.view.io], inserters and extractors
+  template<class charT, class traits>
+    basic_ostream<charT, traits>&
+      operator<<(basic_ostream<charT, traits>& os,
+                 basic_string_view<charT, traits> str);
+
+  // basic_string_view typedef names
+  using string_view    = basic_string_view<char>;
+  using u16string_view = basic_string_view<char16_t>;
+  using u32string_view = basic_string_view<char32_t>;
+  using wstring_view   = basic_string_view<wchar_t>;
+
+  // [string.view.hash], hash support
+  template<class T> struct hash;
+  template<> struct hash<string_view>;
+  template<> struct hash<u16string_view>;
+  template<> struct hash<u32string_view>;
+  template<> struct hash<wstring_view>;
+
+  inline namespace literals {
+  inline namespace string_view_literals {
+    // [string.view.literals], suffix for basic_string_view literals
+    constexpr string_view    operator""sv(const char* str, size_t len) noexcept;
+    constexpr u16string_view operator""sv(const char16_t* str, size_t len)
+        noexcept;
+    constexpr u32string_view operator""sv(const char32_t* str, size_t len)
+        noexcept;
+    constexpr wstring_view   operator""sv(const wchar_t* str, size_t len)
+        noexcept;
+  }}
+}
+
+[string.view.template] Class template basic_string_view [string.view.template]
+
+template<class charT, class traits = char_traits<charT>>
+class basic_string_view {
+public:
+  // types
+  using traits_type            = traits;
+  using value_type             = charT;
+  using pointer                = value_type*;
+  using const_pointer          = const value_type*;
+  using reference              = value_type&;
+  using const_reference        = const value_type&;
+  using const_iterator         = implementation-defined;
+                                 // see [string.view.iterators]
+  using iterator               = const_iterator;
+  using const_reverse_iterator = reverse_iterator<const_iterator>;
+  using reverse_iterator       = const_reverse_iterator;
+  using size_type              = size_t;
+  using difference_type        = ptrdiff_t;
+  static constexpr size_type npos = size_type(-1);
+
+  // [string.view.cons], construction and assignment
+  constexpr basic_string_view() noexcept;
+  constexpr basic_string_view(const basic_string_view&) noexcept = default;
+  constexpr basic_string_view& operator=(const basic_string_view&) noexcept =
+      default;
+  constexpr basic_string_view(const charT* str);
+  constexpr basic_string_view(const charT* str, size_type len);
+
+  // [string.view.iterators], iterator support
+  constexpr const_iterator begin() const noexcept;
+  constexpr const_iterator end() const noexcept;
+  constexpr const_iterator cbegin() const noexcept;
+  constexpr const_iterator cend() const noexcept;
+  constexpr const_reverse_iterator rbegin() const noexcept;
+  constexpr const_reverse_iterator rend() const noexcept;
+  constexpr const_reverse_iterator crbegin() const noexcept;
+  constexpr const_reverse_iterator crend() const noexcept;
+
+  // [string.view.capacity], capacity
+  constexpr size_type size() const noexcept;
+  constexpr size_type length() const noexcept;
+  constexpr size_type max_size() const noexcept;
+  [[nodiscard]] constexpr bool empty() const noexcept;
+
+  // [string.view.access], element access
+  constexpr const_reference operator[](size_type pos) const;
+  constexpr const_reference at(size_type pos) const;
+  constexpr const_reference front() const;
+  constexpr const_reference back() const;
+  constexpr const_pointer data() const noexcept;
+
+  // [string.view.modifiers], modifiers
+  constexpr void remove_prefix(size_type n);
+  constexpr void remove_suffix(size_type n);
+  constexpr void swap(basic_string_view& s) noexcept;
+
+  // [string.view.ops], string operations
+  size_type copy(charT* s, size_type n, size_type pos = 0) const;
+
+  constexpr basic_string_view substr(size_type pos = 0, size_type n = npos)
+      const;
+
+  constexpr int compare(basic_string_view s) const noexcept;
+  constexpr int compare(size_type pos1, size_type n1, basic_string_view s)
+      const;
+  constexpr int compare(size_type pos1, size_type n1, basic_string_view s,
+  size_type pos2, size_type n2) const;
+  constexpr int compare(const charT* s) const;
+  constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
+  constexpr int compare(size_type pos1, size_type n1, const charT* s,
+      size_type n2) const;
+
+  constexpr bool starts_with(basic_string_view x) const noexcept;
+  constexpr bool starts_with(charT x) const noexcept;
+  constexpr bool starts_with(const charT* x) const;
+  constexpr bool ends_with(basic_string_view x) const noexcept;
+  constexpr bool ends_with(charT x) const noexcept;
+  constexpr bool ends_with(const charT* x) const;
+
+  // [string.view.find], searching
+  constexpr size_type find(basic_string_view s, size_type pos = 0) const
+      noexcept;
+  constexpr size_type find(charT c, size_type pos = 0) const noexcept;
+  constexpr size_type find(const charT* s, size_type pos, size_type n) const;
+  constexpr size_type find(const charT* s, size_type pos = 0) const;
+  constexpr size_type rfind(basic_string_view s, size_type pos = npos) const
+      noexcept;
+  constexpr size_type rfind(charT c, size_type pos = npos) const noexcept;
+  constexpr size_type rfind(const charT* s, size_type pos, size_type n) const;
+  constexpr size_type rfind(const charT* s, size_type pos = npos) const;
+
+  constexpr size_type find_first_of(basic_string_view s, size_type pos = 0)
+      const noexcept;
+  constexpr size_type find_first_of(charT c, size_type pos = 0) const noexcept;
+  constexpr size_type find_first_of(const charT* s, size_type pos, size_type n)
+      const;
+  constexpr size_type find_first_of(const charT* s, size_type pos = 0) const;
+  constexpr size_type find_last_of(basic_string_view s, size_type pos = npos)
+      const noexcept;
+  constexpr size_type find_last_of(charT c, size_type pos = npos) const
+      noexcept;
+  constexpr size_type find_last_of(const charT* s, size_type pos, size_type n)
+      const;
+  constexpr size_type find_last_of(const charT* s, size_type pos = npos) const;
+  constexpr size_type find_first_not_of(basic_string_view s, size_type pos = 0)
+      const noexcept;
+  constexpr size_type find_first_not_of(charT c, size_type pos = 0) const
+      noexcept;
+  constexpr size_type find_first_not_of(const charT* s, size_type pos,
+      size_type n) const;
+  constexpr size_type find_first_not_of(const charT* s, size_type pos = 0)
+      const;
+  constexpr size_type find_last_not_of(basic_string_view s, size_type pos =
+      npos) const noexcept;
+  constexpr size_type find_last_not_of(charT c, size_type pos = npos) const
+      noexcept;
+  constexpr size_type find_last_not_of(const charT* s, size_type pos,
+      size_type n) const;
+  constexpr size_type find_last_not_of(const charT* s, size_type pos = npos)
+      const;
+
+private:
+  const_pointer data_; // exposition only
+  size_type size_;     // exposition only
+};
+
+*/
+
+#include "detail/config.hpp"
+#include "detail/lib.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <ios>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace slb {
+namespace detail {
+static constexpr int
+string_compare_sizes(int cmp, std::size_t lhs, std::size_t rhs) noexcept {
+  return cmp != 0 ? cmp : lhs == rhs ? 0 : lhs < rhs ? -1 : +1;
+}
+} // namespace detail
+
+// [string.view.template], class template basic_string_view
+template <typename CharT, typename Traits = std::char_traits<CharT>>
+class basic_string_view {
+  static_assert(std::is_same<typename Traits::char_type, CharT>::value,
+                "Traits::char_type shall be the same as CharT");
+
+  static std::size_t _assert_checked_size(CharT const* str) noexcept {
+    assert(str != nullptr);
+    (void)str;
+    return std::size_t(-1);
+  }
+
+  static constexpr std::size_t _checked_size(CharT const* str) noexcept {
+    return (str != nullptr) ? Traits::length(str) : _assert_checked_size(str);
+  }
+
+  static std::size_t _assert_checked_size(CharT const* str,
+                                          std::size_t len) noexcept {
+    assert(len == 0 || str != nullptr);
+    (void)str;
+    return len;
+  }
+
+  static constexpr std::size_t _checked_size(CharT const* str,
+                                             std::size_t len) noexcept {
+    return (len == 0 || str != nullptr) ? len : _assert_checked_size(str, len);
+  }
+
+  std::size_t _assert_checked_pos(std::size_t pos) const noexcept {
+    assert(pos < _size);
+    return pos;
+  }
+
+  constexpr std::size_t _checked_pos(std::size_t pos) const noexcept {
+    return (pos < _size) ? pos : _assert_checked_pos(pos);
+  }
+
+  struct _unchecked_tag {
+    explicit _unchecked_tag() = default;
+  };
+
+  constexpr basic_string_view(_unchecked_tag,
+                              CharT const* str,
+                              std::size_t size) noexcept
+      : _data(str), _size(size) {}
+
+public:
+  // types
+  using traits_type = Traits;
+  using value_type = CharT;
+  using pointer = value_type*;
+  using const_pointer = value_type const*;
+  using reference = value_type&;
+  using const_reference = value_type const&;
+  using const_iterator = const_pointer; // see [string.view.iterators]
+  using iterator = const_iterator;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+  using reverse_iterator = const_reverse_iterator;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  static constexpr size_type npos = size_type(-1);
+
+  // [string.view.cons], construction and assignment
+  constexpr basic_string_view() noexcept : _data(nullptr), _size(0) {}
+
+  constexpr basic_string_view(basic_string_view const&) noexcept = default;
+
+  SLB_CXX14_CONSTEXPR basic_string_view&
+  operator=(basic_string_view const&) noexcept = default;
+
+  constexpr basic_string_view(CharT const* str) noexcept
+      : _data(str), _size(_checked_size(str)) {}
+  constexpr basic_string_view(CharT const* str, size_type len) noexcept
+      : _data(str), _size(_checked_size(str, len)) {}
+
+  // [string.view.iterators], iterator support
+  constexpr const_iterator begin() const noexcept { return _data; }
+  constexpr const_iterator end() const noexcept { return _data + _size; }
+  constexpr const_iterator cbegin() const noexcept { return _data; }
+  constexpr const_iterator cend() const noexcept { return _data + _size; }
+
+  constexpr const_reverse_iterator rbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
+  constexpr const_reverse_iterator rend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
+  constexpr const_reverse_iterator crbegin() const noexcept {
+    return const_reverse_iterator(end());
+  }
+  constexpr const_reverse_iterator crend() const noexcept {
+    return const_reverse_iterator(begin());
+  }
+
+  // [string.view.capacity], capacity
+  constexpr size_type size() const noexcept { return _size; }
+  constexpr size_type length() const noexcept { return _size; }
+  constexpr size_type max_size() const noexcept {
+    return std::numeric_limits<std::ptrdiff_t>::max();
+  }
+  SLB_CXX17_NODISCARD constexpr bool empty() const noexcept {
+    return _size == 0;
+  }
+
+  // [string.view.access], element access
+  constexpr const_reference operator[](size_type pos) const noexcept {
+    return _data[_checked_pos(pos)];
+  }
+  constexpr const_reference at(size_type pos) const {
+    return pos >= _size ? throw std::out_of_range("slb::basic_string_view::at")
+                        : 0,
+           _data[pos];
+  }
+  constexpr const_reference front() const noexcept {
+    return _data[_checked_pos(0)];
+  }
+  constexpr const_reference back() const noexcept {
+    return _data[_checked_pos(_size - 1)];
+  }
+  constexpr const_pointer data() const noexcept { return _data; }
+
+  // [string.view.modifiers], modifiers
+  SLB_CXX14_CONSTEXPR void remove_prefix(size_type n) noexcept {
+    assert(n <= _size);
+    _data += n;
+    _size -= n;
+  }
+  SLB_CXX14_CONSTEXPR void remove_suffix(size_type n) noexcept {
+    assert(n <= _size);
+    _size -= n;
+  }
+  SLB_CXX14_CONSTEXPR void swap(basic_string_view& s) noexcept {
+    basic_string_view t(*this);
+    _data = s._data;
+    _size = s._size;
+    s._data = t._data;
+    s._size = t._size;
+  }
+
+  // [string.view.ops], string operations
+  size_type copy(CharT* s, size_type n, size_type pos = 0) const {
+    if (pos > _size)
+      throw std::out_of_range("slb::basic_string_view::copy");
+
+    size_type const rlen = (detail::lib::min)(n, _size - pos);
+    assert(s != nullptr || rlen == 0);
+    assert(_data + pos < s || _data + pos >= s + rlen);
+    Traits::copy(s, _data + pos, rlen);
+    return rlen;
+  }
+
+  constexpr basic_string_view substr(size_type pos = 0,
+                                     size_type n = npos) const {
+    return pos > _size
+               ? throw std::out_of_range("slb::basic_string_view::substr")
+               : 0,
+           basic_string_view(_unchecked_tag{},
+                             _data + pos,
+                             (detail::lib::min)(n, _size - pos));
+  }
+
+  constexpr int compare(basic_string_view str) const noexcept {
+    return detail::string_compare_sizes(
+        Traits::compare(_data, str._data, (detail::lib::min)(_size, str._size)),
+        _size,
+        str._size);
+  }
+  constexpr int
+  compare(size_type pos1, size_type n1, basic_string_view str) const noexcept {
+    return substr(pos1, n1).compare(str);
+  }
+  constexpr int compare(size_type pos1,
+                        size_type n1,
+                        basic_string_view str,
+                        size_type pos2,
+                        size_type n2) const noexcept {
+    return substr(pos1, n1).compare(str.substr(pos2, n2));
+  }
+  constexpr int compare(CharT const* s) const noexcept {
+    return compare(basic_string_view(s));
+  }
+  constexpr int compare(size_type pos1, size_type n1, CharT const* s) const
+      noexcept {
+    return substr(pos1, n1).compare(basic_string_view(s));
+  }
+  constexpr int
+  compare(size_type pos1, size_type n1, CharT const* s, size_type n2) const
+      noexcept {
+    return substr(pos1, n1).compare(basic_string_view(s, n2));
+  }
+
+  constexpr bool starts_with(basic_string_view x) const noexcept {
+    return substr(0, x.size()) == x;
+  }
+  constexpr bool starts_with(CharT x) const noexcept {
+    return !empty() && Traits::eq(front(), x);
+  }
+  constexpr bool starts_with(CharT const* x) const noexcept {
+    return starts_with(basic_string_view(x));
+  }
+  constexpr bool ends_with(basic_string_view x) const noexcept {
+    return size() >= x.size() && compare(size() - x.size(), npos, x) == 0;
+  }
+  constexpr bool ends_with(CharT x) const noexcept {
+    return !empty() && Traits::eq(back(), x);
+  }
+  constexpr bool ends_with(CharT const* x) const noexcept {
+    return ends_with(basic_string_view(x));
+  }
+
+  // [string.view.find], searching
+  SLB_CXX14_CONSTEXPR size_type find(basic_string_view str,
+                                     size_type pos = 0) const noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last =
+        _data + (detail::lib::min)(_size - str._size, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      if (Traits::compare(xpos, str._data, str._size) == 0)
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find(CharT c, size_type pos = 0) const
+      noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last = _data + (detail::lib::min)(_size - 1, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      if (Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find(CharT const* s,
+                                     size_type pos,
+                                     size_type n) const noexcept {
+    return find(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type find(CharT const* s, size_type pos = 0) const
+      noexcept {
+    return find(basic_string_view(s), pos);
+  }
+
+  SLB_CXX14_CONSTEXPR size_type rfind(basic_string_view str,
+                                      size_type pos = npos) const noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - str._size, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      if (Traits::compare(xpos, str._data, str._size) == 0)
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type rfind(CharT c, size_type pos = npos) const
+      noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - 1, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      if (Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type rfind(CharT const* s,
+                                      size_type pos,
+                                      size_type n) const noexcept {
+    return rfind(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type rfind(CharT const* s,
+                                      size_type pos = npos) const noexcept {
+    return rfind(basic_string_view(s), pos);
+  }
+
+  SLB_CXX14_CONSTEXPR size_type find_first_of(basic_string_view str,
+                                              size_type pos = 0) const
+      noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last = _data + (detail::lib::min)(_size - 1, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      for (size_type i = 0; i < str._size; ++i)
+        if (Traits::eq(*xpos, str._data[i]))
+          return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_of(CharT c, size_type pos = 0) const
+      noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last = _data + (detail::lib::min)(_size - 1, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      if (Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_of(CharT const* s,
+                                              size_type pos,
+                                              size_type n) const noexcept {
+    return find_first_of(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_of(CharT const* s,
+                                              size_type pos = 0) const
+      noexcept {
+    return find_first_of(basic_string_view(s), pos);
+  }
+
+  SLB_CXX14_CONSTEXPR size_type find_last_of(basic_string_view str,
+                                             size_type pos = npos) const
+      noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - 1, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      for (size_type i = 0; i < str._size; ++i)
+        if (Traits::eq(*xpos, str._data[i]))
+          return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_of(CharT c,
+                                             size_type pos = npos) const
+      noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - 1, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      if (Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_of(CharT const* s,
+                                             size_type pos,
+                                             size_type n) const noexcept {
+    return find_last_of(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_of(CharT const* s,
+                                             size_type pos = npos) const
+      noexcept {
+    return find_last_of(basic_string_view(s), pos);
+  }
+
+  SLB_CXX14_CONSTEXPR size_type find_first_not_of(basic_string_view str,
+                                                  size_type pos = 0) const
+      noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last = _data + (detail::lib::min)(_size - 1, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      size_type i = 0;
+      while (i < str._size && !Traits::eq(*xpos, str._data[i]))
+        ++i;
+      if (i == str._size)
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_not_of(CharT c,
+                                                  size_type pos = 0) const
+      noexcept {
+    const_pointer const first = _data + (detail::lib::min)(pos, _size);
+    const_pointer const last = _data + (detail::lib::min)(_size - 1, _size);
+    for (const_pointer xpos = first; xpos < last; ++xpos) {
+      if (!Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_not_of(CharT const* s,
+                                                  size_type pos,
+                                                  size_type n) const noexcept {
+    return find_first_not_of(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type find_first_not_of(CharT const* s,
+                                                  size_type pos = 0) const
+      noexcept {
+    return find_first_not_of(basic_string_view(s), pos);
+  }
+
+  SLB_CXX14_CONSTEXPR size_type find_last_not_of(basic_string_view str,
+                                                 size_type pos = npos) const
+      noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - 1, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      size_type i = 0;
+      while (i < str._size && !Traits::eq(*xpos, str._data[i]))
+        ++i;
+      if (i == str._size)
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_not_of(CharT c,
+                                                 size_type pos = npos) const
+      noexcept {
+    const_pointer const first = _data;
+    const_pointer const last =
+        _data + (detail::lib::min)(pos, _size - 1, _size);
+    for (const_pointer xpos = last; xpos >= first; --xpos) {
+      if (!Traits::eq(*xpos, c))
+        return xpos - _data;
+    }
+    return npos;
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_not_of(CharT const* s,
+                                                 size_type pos,
+                                                 size_type n) const noexcept {
+    return find_last_not_of(basic_string_view(s, n), pos);
+  }
+  SLB_CXX14_CONSTEXPR size_type find_last_not_of(CharT const* s,
+                                                 size_type pos = npos) const
+      noexcept {
+    return find_last_not_of(basic_string_view(s), pos);
+  }
+
+private:
+  const_pointer _data;
+  size_type _size;
+};
+
+template <typename CharT, typename Traits>
+constexpr typename basic_string_view<CharT, Traits>::size_type
+    basic_string_view<CharT, Traits>::npos;
+
+// [string.view.comparison], non-member comparison functions
+namespace detail {
+template <typename U, typename CharT, typename Traits>
+struct enable_string_view_convertible
+    : std::enable_if<
+          !std::is_same<typename detail::lib::remove_cvref<U>::type,
+                        basic_string_view<CharT, Traits>>::value &&
+          std::is_convertible<U, basic_string_view<CharT, Traits>>::value> {};
+} // namespace detail
+
+template <typename CharT, typename Traits>
+constexpr bool operator==(basic_string_view<CharT, Traits> x,
+                          basic_string_view<CharT, Traits> y) noexcept {
+  return x.size() == y.size() && x.compare(y) == 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator==(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) == y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator==(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x == basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+template <typename CharT, typename Traits>
+constexpr bool operator!=(basic_string_view<CharT, Traits> x,
+                          basic_string_view<CharT, Traits> y) noexcept {
+  return x.size() != y.size() || x.compare(y) != 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator!=(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) != y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator!=(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x != basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+template <typename CharT, typename Traits>
+constexpr bool operator<(basic_string_view<CharT, Traits> x,
+                         basic_string_view<CharT, Traits> y) noexcept {
+  return x.compare(y) < 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator<(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) < y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator<(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x < basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+template <typename CharT, typename Traits>
+constexpr bool operator>(basic_string_view<CharT, Traits> x,
+                         basic_string_view<CharT, Traits> y) noexcept {
+  return x.compare(y) > 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator>(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) > y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator>(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x > basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+template <typename CharT, typename Traits>
+constexpr bool operator<=(basic_string_view<CharT, Traits> x,
+                          basic_string_view<CharT, Traits> y) noexcept {
+  return x.compare(y) <= 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator<=(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) <= y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator<=(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x <= basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+template <typename CharT, typename Traits>
+constexpr bool operator>=(basic_string_view<CharT, Traits> x,
+                          basic_string_view<CharT, Traits> y) noexcept {
+  return x.compare(y) >= 0;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator>=(U&& x, basic_string_view<CharT, Traits> y) noexcept {
+  return basic_string_view<CharT, Traits>(static_cast<U&&>(x)) >= y;
+}
+template <
+    typename CharT,
+    typename Traits,
+    typename U,
+    typename Enable =
+        typename detail::enable_string_view_convertible<U, CharT, Traits>::type>
+constexpr bool operator>=(basic_string_view<CharT, Traits> x, U&& y) noexcept {
+  return x >= basic_string_view<CharT, Traits>(static_cast<U&&>(y));
+}
+
+// [string.view.io], inserters and extractors
+namespace detail {
+template <typename CharT, typename Traits>
+bool string_io_pad(std::basic_ostream<CharT, Traits>& os,
+                   std::streamsize const pad) {
+  CharT const fill = os.fill();
+  CharT const chunk[] = {
+      fill, fill, fill, fill, fill, fill, fill, fill, fill, fill, fill, fill};
+  std::streamsize constexpr chunk_size = sizeof(chunk) / sizeof(CharT);
+
+  bool good = true;
+  for (std::streamsize i = 0; i < pad; i += chunk_size) {
+    std::streamsize const rlen = (detail::lib::min)(chunk_size, pad - i);
+    good = good && os.rdbuf()->sputn(chunk, rlen);
+  }
+  return good;
+}
+} // namespace detail
+
+template <typename CharT, typename Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os,
+           basic_string_view<CharT, Traits> str) {
+  typename std::basic_ostream<CharT, Traits>::sentry sentry(os);
+
+  bool good(sentry);
+  if (good) {
+    try {
+      std::streamsize const len = str.size();
+      std::streamsize const pad = os.width() - len;
+      bool const left_pad =
+          (os.flags() & std::ios_base::adjustfield) == std::ios_base::left;
+
+      good = good && (pad < 0 || !left_pad || detail::string_io_pad(os, pad));
+      good = good && os.rdbuf()->sputn(str.data(), len) == len;
+      good = good && (pad < 0 || left_pad || detail::string_io_pad(os, pad));
+    } catch (...) {
+      os.setstate(std::ios_base::badbit);
+    }
+  }
+  if (!good) {
+    os.setstate(std::ios_base::failbit);
+  }
+  os.width(0); // reset width
+
+  return os;
+}
+
+// basic_string_view typedef names
+using string_view = basic_string_view<char>;
+using u16string_view = basic_string_view<char16_t>;
+using u32string_view = basic_string_view<char32_t>;
+using wstring_view = basic_string_view<wchar_t>;
+
+// [string.view.hash], hash support
+namespace detail {
+template <typename CharT>
+std::size_t string_hash(CharT const* data, std::size_t len) {
+  CharT const* const first = data;
+  CharT const* const last = data + len;
+
+  std::size_t result = 2166136261;
+  for (CharT const* ptr = first; ptr < last; ++ptr) {
+    result = (result * 16777619) ^ *ptr;
+  }
+  return result;
+}
+} // namespace detail
+
+template <typename T>
+struct hash;
+
+template <>
+struct hash<string_view> {
+  std::size_t operator()(string_view str) const noexcept {
+    return detail::string_hash(str.data(), str.length());
+  }
+};
+
+template <>
+struct hash<u16string_view> {
+  std::size_t operator()(u16string_view str) const noexcept {
+    return detail::string_hash(str.data(), str.length());
+  }
+};
+
+template <>
+struct hash<u32string_view> {
+  std::size_t operator()(u32string_view str) const noexcept {
+    return detail::string_hash(str.data(), str.length());
+  }
+};
+
+template <>
+struct hash<wstring_view> {
+  std::size_t operator()(wstring_view str) const noexcept {
+    return detail::string_hash(str.data(), str.length());
+  }
+};
+
+inline namespace literals {
+inline namespace string_view_literals {
+// [string.view.literals], suffix for basic_string_view literals
+constexpr string_view operator"" _sv(char const* str,
+                                     std::size_t len) noexcept {
+  return string_view{str, len};
+}
+constexpr u16string_view operator"" _sv(char16_t const* str,
+                                        std::size_t len) noexcept {
+  return u16string_view{str, len};
+}
+constexpr u32string_view operator"" _sv(char32_t const* str,
+                                        std::size_t len) noexcept {
+  return u32string_view{str, len};
+}
+constexpr wstring_view operator"" _sv(wchar_t const* str,
+                                      std::size_t len) noexcept {
+  return wstring_view{str, len};
+}
+} // namespace string_view_literals
+} // namespace literals
+} // namespace slb
+
+namespace std {
+template <>
+struct hash<slb::string_view> : slb::hash<slb::string_view> {};
+template <>
+struct hash<slb::u16string_view> : slb::hash<slb::u16string_view> {};
+template <>
+struct hash<slb::u32string_view> : slb::hash<slb::u32string_view> {};
+template <>
+struct hash<slb::wstring_view> : slb::hash<slb::wstring_view> {};
+} // namespace std
+
+#endif // SLB_STRING_VIEW_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(_tests
   functional/invoke
   functional/mem_fn
   functional/not_fn
+  string_view
   type_traits
   utility)
 foreach(_test ${_tests})
@@ -24,15 +25,27 @@ foreach(_test ${_tests})
   target_link_libraries(test.${_test} SLB)
   set_property(TARGET test.${_test} PROPERTY FOLDER "test/${_test_folder}")
 
+  set(_instantiations )
   file(STRINGS ${_test_file} _lines)
   foreach(_line ${_lines})
-    if(_line MATCHES "^TEST_CASE\\(\"([A-Za-z_0-9()-]+)\"")
-      set(_case ${CMAKE_MATCH_1})
+    if(_line MATCHES "^#define SLB_INSTANTIATION \"([A-Za-z_0-9:()-]+)\"")
+      list(APPEND _instantiations ${CMAKE_MATCH_1})
+    elseif(_line MATCHES "^TEST_CASE\\(\"([A-Za-z_0-9:()-]+)\"")
+      set(_case "${CMAKE_MATCH_1}")
       string(MAKE_C_IDENTIFIER ${_case} _case_id)
 
       add_test(
         NAME test.${_test}.${_case_id}
         COMMAND test.${_test} "${_case}")
+    elseif(_line MATCHES "^TEST_CASE\\(SLB_INSTANTIATION( \"([A-Za-z_0-9:()-=]+)\")?")
+      foreach(_instantiation ${_instantiations})
+        set(_case "${_instantiation}${CMAKE_MATCH_2}")
+        string(MAKE_C_IDENTIFIER ${_case} _case_id)
+
+        add_test(
+          NAME test.${_test}.${_case_id}
+          COMMAND test.${_test} "${_case}")
+      endforeach()
     endif()
   endforeach()
 endforeach()

--- a/test/string_view.cpp
+++ b/test/string_view.cpp
@@ -1,0 +1,1777 @@
+/*
+  SLB.String_View
+
+  Copyright Michael Park, 2017
+  Copyright Agustin Berge, 2017
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef SLB_INSTANTIATION
+
+#include <slb/string_view.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "catch.hpp"
+
+#if (__cpp_lib_array_constexpr && __cplusplus >= 201703L) ||                   \
+    (_LIBCPP_VERSION >= 4000 && _LIBCPP_STD_VER > 17) ||                       \
+    (defined(_MSC_VER) && _MSC_VER >= 1914 && _HAS_CXX17)
+#define SLB_CONSTEXPR_REVERSE_ITERATOR constexpr
+#else
+#define SLB_CONSTEXPR_REVERSE_ITERATOR
+#endif
+
+#define CHECK_CXX14_CONSTEXPR(Tag, ...)                                        \
+  struct check_cxx14_constexpr_##Tag {                                         \
+    static SLB_CXX14_CONSTEXPR bool check(){__VA_ARGS__};                      \
+  };                                                                           \
+  CHECK(check_cxx14_constexpr_##Tag::check())
+
+#define CHECK_NESTED(...)                                                      \
+  do {                                                                         \
+    INFO(__FILE__ "(" << __LINE__ << "): " #__VA_ARGS__);                      \
+    check_##__VA_ARGS__;                                                       \
+  } while (false)
+
+template <typename T, std::size_t N>
+constexpr std::size_t countof(T const (&)[N]) noexcept {
+  return N;
+}
+
+// [string.view.io], inserters and extractors
+template <typename CharT, typename string_view = slb::basic_string_view<CharT>>
+void check_inserter() {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  string_view const sv(str, countof(str));
+  std::basic_ostringstream<CharT> stream;
+  stream << sv;
+
+  auto const s = stream.str();
+  CHECK(string_view(s.c_str()) == sv);
+
+  /* padding */
+  {
+    static constexpr CharT lstr[] = {'.', '.', 'f', 'o', 'o'};
+    static constexpr CharT rstr[] = {'f', 'o', 'o', '.', '.'};
+
+    std::basic_ostringstream<CharT> lstream;
+    lstream.setf(std::ios_base::left, std::ios_base::adjustfield);
+    lstream.fill('.');
+    lstream.width(5);
+    lstream << sv;
+
+    auto const ls = lstream.str();
+    CHECK(string_view(ls.c_str()) == string_view(lstr, 5));
+    CHECK(lstream.width() == 0);
+
+    std::basic_ostringstream<CharT> rstream;
+    rstream.setf(std::ios_base::right, std::ios_base::adjustfield);
+    rstream.fill('.');
+    rstream.width(5);
+    rstream << sv;
+
+    auto const rs = rstream.str();
+    CHECK(string_view(rs.c_str()) == string_view(rstr, 5));
+    CHECK(rstream.width() == 0);
+
+    std::basic_ostringstream<CharT> istream;
+    istream.setf(std::ios_base::internal, std::ios_base::adjustfield);
+    istream.fill('.');
+    istream.width(5);
+    istream << sv;
+
+    auto const is = istream.str();
+    CHECK(string_view(is.c_str()) == string_view(rstr, 5));
+    CHECK(istream.width() == 0);
+  }
+}
+
+TEST_CASE("basic_string_view(inserters-and-extractors)", "[string.view.io]") {
+  CHECK_NESTED(inserter<char>());
+  //! CHECK_NESTED(inserter<char16_t>());
+  //! CHECK_NESTED(inserter<char32_t>());
+  CHECK_NESTED(inserter<wchar_t>());
+}
+
+// basic_string_view typedef names
+TEST_CASE("basic_string_view(typedef-names)", "[string.view.synop]") {
+  /* using string_view = basic_string_view<char>; */ {
+    CHECK(std::is_same<slb::string_view, slb::basic_string_view<char>>::value);
+    CHECK(std::is_same<
+          slb::string_view,
+          slb::basic_string_view<char, std::char_traits<char>>>::value);
+  }
+
+  /* using u16string_view = basic_string_view<char16_t>; */ {
+    CHECK(std::is_same<slb::u16string_view,
+                       slb::basic_string_view<char16_t>>::value);
+    CHECK(std::is_same<
+          slb::u16string_view,
+          slb::basic_string_view<char16_t, std::char_traits<char16_t>>>::value);
+  }
+
+  /* using u32string_view = basic_string_view<char32_t>; */ {
+    CHECK(std::is_same<slb::u32string_view,
+                       slb::basic_string_view<char32_t>>::value);
+    CHECK(std::is_same<
+          slb::u32string_view,
+          slb::basic_string_view<char32_t, std::char_traits<char32_t>>>::value);
+  }
+
+  /* using wstring_view = basic_string_view<wchar_t>; */ {
+    CHECK(std::is_same<slb::wstring_view,
+                       slb::basic_string_view<wchar_t>>::value);
+    CHECK(std::is_same<
+          slb::wstring_view,
+          slb::basic_string_view<wchar_t, std::char_traits<wchar_t>>>::value);
+  }
+}
+
+// [string.view.hash], hash support
+template <typename CharT, typename string_view = slb::basic_string_view<CharT>>
+void check_hash() {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  slb::hash<string_view> const h{};
+  string_view const sv1(str, countof(str));
+  string_view const sv2(str, countof(str));
+
+  CHECK(std::is_same<decltype(h(sv1)), std::size_t>::value);
+  CHECK(noexcept(h(sv1)));
+  std::size_t const r = h(sv1);
+  CHECK(h(sv2) == r);
+
+  /* enabled */ {
+    using hasher = slb::hash<string_view>;
+
+    CHECK(std::is_default_constructible<hasher>::value);
+    CHECK(std::is_copy_constructible<hasher>::value);
+    CHECK(std::is_move_constructible<hasher>::value);
+    CHECK(std::is_copy_assignable<hasher>::value);
+    CHECK(std::is_move_assignable<hasher>::value);
+    CHECK(std::is_destructible<hasher>::value);
+  }
+
+  /* std-compatible */ {
+    std::hash<string_view> const std_h{};
+
+    CHECK(std_h(sv2) == r);
+  }
+}
+
+TEST_CASE("basic_string_view(hash-support)", "[string.view.hash]") {
+  CHECK_NESTED(hash<char>());
+  CHECK_NESTED(hash<char16_t>());
+  CHECK_NESTED(hash<char32_t>());
+  CHECK_NESTED(hash<wchar_t>());
+}
+
+// [string.view.literals], suffix for basic_string_view literals
+TEST_CASE("basic_string_view(literals)", "[string.view.literals]") {
+  using namespace slb::literals::string_view_literals;
+
+  CHECK(std::is_same<decltype("foo"_sv), slb::string_view>::value);
+  CHECK("foo"_sv == slb::string_view{"foo", 3});
+  constexpr slb::string_view sv = "foo"_sv;
+  (void)sv;
+
+  CHECK(std::is_same<decltype(u"foo"_sv), slb::u16string_view>::value);
+  CHECK(u"foo"_sv == slb::u16string_view{u"foo", 3});
+  constexpr slb::u16string_view u16sv = u"foo"_sv;
+  (void)u16sv;
+
+  CHECK(std::is_same<decltype(U"foo"_sv), slb::u32string_view>::value);
+  CHECK(U"foo"_sv == slb::u32string_view{U"foo", 3});
+  constexpr slb::u32string_view u32sv = U"foo"_sv;
+  (void)u32sv;
+
+  CHECK(std::is_same<decltype(L"foo"_sv), slb::wstring_view>::value);
+  CHECK(L"foo"_sv == slb::wstring_view{L"foo", 3});
+  constexpr slb::wstring_view wsv = L"foo"_sv;
+  (void)wsv;
+}
+
+// [string.view.template], class template basic_string_view
+
+struct CharT {
+  char val;
+  constexpr CharT(char val = 0) : val(val) {}
+};
+
+struct Traits {
+  using char_type = CharT;
+
+  static SLB_CXX14_CONSTEXPR void assign(CharT& r, CharT const& d) noexcept {
+    r = d;
+  }
+
+  static constexpr bool eq(CharT c, CharT d) noexcept {
+    return static_cast<unsigned char>(c.val) ==
+           static_cast<unsigned char>(d.val);
+  }
+
+  static constexpr bool lt(CharT c, CharT d) noexcept {
+    return static_cast<unsigned char>(c.val) <
+           static_cast<unsigned char>(d.val);
+  }
+
+  static constexpr int compare(CharT const* p, CharT const* q, std::size_t n) {
+    return n == 0 ? 0
+                  : eq(*p, *q) ? compare(p + 1, q + 1, n - 1)
+                               : lt(*p, *q) ? -1 : 1;
+  }
+
+  static constexpr std::size_t length(CharT const* p) {
+    return eq(*p, CharT()) ? 0 : length(p + 1) + 1;
+  }
+
+  static CharT* copy(CharT* s, CharT const* p, std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i)
+      assign(s[i], p[i]);
+    return s;
+  }
+};
+
+#define SLB_INSTANTIATION "basic_string_view<CharT, Traits>"
+#define SLB_CONSTEXPR_CHAR_TRAITS constexpr
+#define SLB_CXX14_CONSTEXPR_CHAR_TRAITS SLB_CXX14_CONSTEXPR
+#include "string_view.cpp"
+#undef SLB_INSTANTIATION
+#undef SLB_CONSTEXPR_CHAR_TRAITS
+#undef SLB_CXX14_CONSTEXPR_CHAR_TRAITS
+
+#define SLB_CONSTEXPR_CHAR_TRAITS
+#define SLB_CXX14_CONSTEXPR_CHAR_TRAITS
+
+// basic_string_view<char, std::char_traits<char>>
+#define SLB_INSTANTIATION "string_view"
+namespace test_string_view {
+using CharT = char;
+using Traits = std::char_traits<char>;
+#include "string_view.cpp"
+} // namespace test_string_view
+#undef SLB_INSTANTIATION
+
+// basic_string_view<char16_t, std::char_traits<char16_t>>
+#define SLB_INSTANTIATION "u16string_view"
+namespace test_u16string_view {
+using CharT = char16_t;
+using Traits = std::char_traits<char16_t>;
+#include "string_view.cpp"
+} // namespace test_u16string_view
+#undef SLB_INSTANTIATION
+
+// basic_string_view<char32_t, std::char_traits<char32_t>>
+#define SLB_INSTANTIATION "u32string_view"
+namespace test_u32string_view {
+using CharT = char32_t;
+using Traits = std::char_traits<char32_t>;
+#include "string_view.cpp"
+} // namespace test_u32string_view
+#undef SLB_INSTANTIATION
+
+// basic_string_view<wchar_t, std::char_traits<wchar_t>>
+#define SLB_INSTANTIATION "wstring_view"
+namespace test_wstring_view {
+using CharT = wchar_t;
+using Traits = std::char_traits<wchar_t>;
+#include "string_view.cpp"
+} // namespace test_wstring_view
+#undef SLB_INSTANTIATION
+
+#else
+
+using string_view = slb::basic_string_view<CharT, Traits>;
+
+TEST_CASE(SLB_INSTANTIATION, "[string.view.template]") {
+  /* using traits_type = traits; */ {
+    CHECK(std::is_same<string_view::traits_type, Traits>::value);
+    CHECK(std::is_same<slb::basic_string_view<CharT>::traits_type,
+                       std::char_traits<CharT>>::value);
+  }
+
+  /* using value_type = charT; */ {
+    CHECK(std::is_same<string_view::value_type, CharT>::value);
+  }
+
+  /* using pointer = value_type*; */
+  /* using const_pointer = const value_type*; */ {
+    CHECK(std::is_same<string_view::pointer, CharT*>::value);
+    CHECK(std::is_same<string_view::const_pointer, CharT const*>::value);
+  }
+
+  /* using reference = value_type&; */
+  /* using const_reference = const value_type&; */ {
+    CHECK(std::is_same<string_view::reference, CharT&>::value);
+    CHECK(std::is_same<string_view::const_reference, CharT const&>::value);
+  }
+
+  /* using const_iterator = implementation-defined; */
+  /* using iterator = const_iterator; */ {
+    // A type that meets the requirements of a constant random access iterator
+    // (27.2.7) and of a contiguous iterator (27.2.1) whose value_type is the
+    // template parameter charT.
+    using iter_traits = std::iterator_traits<string_view::const_iterator>;
+    CHECK(std::is_same<iter_traits::value_type, CharT>::value);
+    CHECK(std::is_same<iter_traits::pointer, CharT const*>::value);
+    CHECK(std::is_same<iter_traits::reference, CharT const&>::value);
+    CHECK(std::is_same<iter_traits::iterator_category,
+                       std::random_access_iterator_tag>::value);
+
+    CHECK(std::is_same<string_view::iterator,
+                       string_view::const_iterator>::value);
+
+    // CHECK(contiguous iterator?)
+  }
+
+  /* using const_reverse_iterator = reverse_iterator<const_iterator>; */
+  /* using reverse_iterator = const_reverse_iterator; */ {
+    CHECK(std::is_same<
+          string_view::const_reverse_iterator,
+          std::reverse_iterator<string_view::const_iterator>>::value);
+    CHECK(std::is_same<string_view::reverse_iterator,
+                       string_view::const_reverse_iterator>::value);
+  }
+
+  /* using size_type = size_t; */ {
+    CHECK(std::is_same<string_view::size_type, std::size_t>::value);
+  }
+
+  /* using difference_type = ptrdiff_t; */ {
+    CHECK(std::is_same<string_view::difference_type, std::ptrdiff_t>::value);
+  }
+
+  /* static constexpr size_type npos = size_type(-1); */ {
+    CHECK(std::is_same<decltype(string_view::npos),
+                       string_view::size_type const>::value);
+    CHECK(string_view::npos == string_view::size_type(-1));
+    constexpr string_view::size_type npos = string_view::npos;
+    (void)npos;
+  }
+}
+
+// [string.view.cons], construction and assignment
+TEST_CASE(SLB_INSTANTIATION "::basic_string_view", "[string.view.cons]") {
+  static constexpr CharT str[] = {'f', 'o', 'o', '\0', 'b', 'a', 'r'};
+
+  /* constexpr basic_string_view() noexcept; */ {
+    constexpr string_view sv;
+    CHECK(noexcept(string_view()));
+    CHECK(sv.data() == nullptr);
+    CHECK(sv.size() == 0);
+
+    /* implicit */ {
+      constexpr string_view isv = {};
+      CHECK(isv.data() == nullptr);
+      CHECK(isv.size() == 0);
+    }
+  }
+
+  /* constexpr basic_string_view(const charT* str); */ {
+    SLB_CONSTEXPR_CHAR_TRAITS string_view sv(str);
+    CHECK(sv.data() == str);
+    CHECK(sv.size() == Traits::length(str));
+
+    /* implicit */ {
+      SLB_CONSTEXPR_CHAR_TRAITS string_view isv = str;
+      CHECK(isv.data() == str);
+      CHECK(isv.size() == Traits::length(str));
+    }
+  }
+
+  /* constexpr basic_string_view(const charT* str, size_type len); */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(sv.data() == str);
+    CHECK(sv.size() == countof(str));
+
+    /* implicit */ {
+      constexpr string_view isv = {str, countof(str)};
+      CHECK(isv.data() == str);
+      CHECK(isv.size() == countof(str));
+    }
+  }
+
+  /* constexpr basic_string_view(const basic_string_view&) noexcept = default;
+   */
+  {
+    constexpr string_view src(str, countof(str));
+    constexpr string_view sv(src);
+    CHECK(noexcept(string_view(src)));
+    CHECK(sv.data() == src.data());
+    CHECK(sv.size() == src.size());
+  }
+}
+
+TEST_CASE(SLB_INSTANTIATION "::operator=", "[string.view.cons]") {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  // constexpr basic_string_view& operator=(const basic_string_view&) noexcept =
+  //     default;
+  constexpr string_view src(str, countof(str));
+  string_view sv;
+  sv = src;
+  CHECK(noexcept(sv = src));
+  CHECK(sv.data() == src.data());
+  CHECK(sv.size() == src.size());
+
+  CHECK_CXX14_CONSTEXPR(assign_op, {
+    string_view src(str, countof(str));
+    string_view sv;
+    sv = src;
+    return sv.data() == src.data() && sv.size() == src.size();
+  });
+}
+
+// [string.view.iterators], iterator support
+TEST_CASE(SLB_INSTANTIATION "(iterator-support)", "[string.view.iterators]") {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  /* constexpr const_iterator begin() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(
+        std::is_same<decltype(sv.begin()), string_view::const_iterator>::value);
+    CHECK(noexcept(sv.begin()));
+    CHECK(&*sv.begin() == sv.data());
+    constexpr auto begin = sv.begin();
+    (void)begin;
+
+    constexpr string_view esv;
+    CHECK(esv.begin() == esv.end());
+  }
+
+  /* constexpr const_iterator cbegin() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.cbegin()),
+                       string_view::const_iterator>::value);
+    CHECK(noexcept(sv.cbegin()));
+    CHECK(sv.cbegin() == sv.begin());
+    constexpr auto cbegin = sv.cbegin();
+    (void)cbegin;
+
+    constexpr string_view esv;
+    CHECK(esv.cbegin() == esv.cend());
+  }
+
+  /* constexpr const_iterator end() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.end()), string_view::const_iterator>::value);
+    CHECK(noexcept(sv.end()));
+    CHECK(sv.end() == sv.begin() + sv.size());
+    constexpr auto end = sv.end();
+    (void)end;
+  }
+
+  /* constexpr const_iterator cend() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(
+        std::is_same<decltype(sv.cend()), string_view::const_iterator>::value);
+    CHECK(noexcept(sv.cend()));
+    CHECK(sv.cend() == sv.end());
+    constexpr auto cend = sv.cend();
+    (void)cend;
+  }
+
+  /* constexpr const_reverse_iterator rbegin() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.rbegin()),
+                       string_view::const_reverse_iterator>::value);
+    CHECK(noexcept(sv.rbegin()));
+    CHECK(sv.rbegin().base() == sv.end());
+    SLB_CONSTEXPR_REVERSE_ITERATOR auto rbegin = sv.rbegin();
+    (void)rbegin;
+  }
+
+  /* constexpr const_reverse_iterator crbegin() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    SLB_CONSTEXPR_REVERSE_ITERATOR auto crbegin = sv.crbegin();
+    (void)crbegin;
+  }
+
+  /* constexpr const_reverse_iterator rend() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.rend()),
+                       string_view::const_reverse_iterator>::value);
+    CHECK(noexcept(sv.rend()));
+    CHECK(sv.rend().base() == sv.begin());
+    SLB_CONSTEXPR_REVERSE_ITERATOR auto rend = sv.rend();
+    (void)rend;
+  }
+
+  /* constexpr const_reverse_iterator crend() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.crend()),
+                       string_view::const_reverse_iterator>::value);
+    CHECK(noexcept(sv.crend()));
+    CHECK(sv.crend() == sv.rend());
+    SLB_CONSTEXPR_REVERSE_ITERATOR auto crend = sv.crend();
+    (void)crend;
+  }
+}
+
+// [string.view.capacity], capacity
+TEST_CASE(SLB_INSTANTIATION "(capacity)", "[string.view.capacity]") {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  /* constexpr size_type size() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.size()), string_view::size_type>::value);
+    CHECK(noexcept(sv.size()));
+    CHECK(sv.size() == countof(str));
+    constexpr auto size = sv.size();
+    (void)size;
+  }
+
+  /* constexpr size_type length() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.length()), string_view::size_type>::value);
+    CHECK(noexcept(sv.length()));
+    CHECK(sv.length() == sv.size());
+    constexpr auto length = sv.length();
+    (void)length;
+  }
+
+  /* constexpr size_type max_size() const noexcept; */ {
+    constexpr string_view sv;
+    CHECK(std::is_same<decltype(sv.max_size()), string_view::size_type>::value);
+    CHECK(noexcept(sv.max_size()));
+    CHECK(sv.max_size() > 0);
+    constexpr auto max_size = sv.max_size();
+    (void)max_size;
+  }
+
+  /* [[nodiscard]] constexpr bool empty() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.empty()), bool>::value);
+    CHECK(noexcept(sv.empty()));
+    CHECK_FALSE(sv.empty());
+    constexpr auto empty = sv.empty();
+    (void)empty;
+
+    constexpr string_view esv;
+    CHECK(esv.empty());
+  }
+}
+
+// [string.view.access], element access
+TEST_CASE(SLB_INSTANTIATION "(element-access)", "[string.view.access]") {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  /* constexpr const_reference operator[](size_type pos) const; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv[0]), string_view::const_reference>::value);
+    CHECK(&sv[0] == &str[0]);
+    CHECK(&sv[1] == &str[1]);
+    CHECK(&sv[2] == &str[2]);
+    constexpr auto&& subscript_op = sv[0];
+    (void)subscript_op;
+  }
+
+  /* constexpr const_reference at(size_type pos) const; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(
+        std::is_same<decltype(sv.at(0)), string_view::const_reference>::value);
+    CHECK(&sv.at(0) == &str[0]);
+    CHECK(&sv.at(1) == &str[1]);
+    CHECK(&sv.at(2) == &str[2]);
+    CHECK_THROWS_AS(sv.at(sv.size()), std::out_of_range);
+    constexpr auto&& at = sv.at(0);
+    (void)at;
+  }
+
+  /* constexpr const_reference front() const; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.front()),
+                       string_view::const_reference>::value);
+    CHECK(&sv.front() == &str[0]);
+    constexpr auto&& front = sv.front();
+    (void)front;
+  }
+
+  /* constexpr const_reference back() const; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(
+        std::is_same<decltype(sv.back()), string_view::const_reference>::value);
+    CHECK(&sv.back() == &str[countof(str) - 1]);
+    constexpr auto&& back = sv.back();
+    (void)back;
+  }
+
+  /* constexpr const_pointer data() const noexcept; */ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.data()), string_view::const_pointer>::value);
+    CHECK(noexcept(sv.data()));
+    CHECK(sv.data() == str);
+    constexpr auto* data = sv.data();
+    (void)data;
+
+    constexpr string_view esv;
+    CHECK(esv.data() == nullptr);
+  }
+}
+
+// [string.view.modifiers], modifiers
+TEST_CASE(SLB_INSTANTIATION "(modifiers)", "[string.view.modifiers]") {
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+
+  /* constexpr void remove_prefix(size_type n); */ {
+    string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.remove_prefix(2)), void>::value);
+    sv.remove_prefix(2);
+    CHECK(sv.data() == str + 2);
+    CHECK(sv.size() == countof(str) - 2);
+
+    CHECK_CXX14_CONSTEXPR(remove_prefix, {
+      string_view sv(str, countof(str));
+      sv.remove_prefix(2);
+      return sv.data() == str + 2 && sv.size() == countof(str) - 2;
+    });
+  }
+
+  /* constexpr void remove_suffix(size_type n); */ {
+    string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.remove_suffix(2)), void>::value);
+    sv.remove_suffix(2);
+    CHECK(sv.data() == str);
+    CHECK(sv.size() == countof(str) - 2);
+
+    CHECK_CXX14_CONSTEXPR(remove_suffix, {
+      string_view sv(str, countof(str));
+      sv.remove_suffix(2);
+      return sv.data() == str && sv.size() == countof(str) - 2;
+    });
+  }
+
+  /* constexpr void swap(basic_string_view& s) noexcept; */ {
+    string_view sv1(str, countof(str)), sv2;
+    CHECK(std::is_same<decltype(sv1.swap(sv2)), void>::value);
+    CHECK(noexcept(sv1.swap(sv2)));
+    sv1.swap(sv2);
+    CHECK(sv1.data() == nullptr);
+    CHECK(sv1.size() == 0);
+    CHECK(sv2.data() == str);
+    CHECK(sv2.size() == countof(str));
+
+    CHECK_CXX14_CONSTEXPR(swap, {
+      string_view sv1(str, countof(str)), sv2;
+      sv1.swap(sv2);
+      return sv1.data() == nullptr && sv1.size() == 0 && sv2.data() == str &&
+             sv2.size() == countof(str);
+    });
+  }
+}
+
+// [string.view.ops], string operations
+TEST_CASE(SLB_INSTANTIATION "(string-operations)", "[string.view.ops]") {
+  static constexpr CharT str_smaller[] = {'f', 'o'};
+  static constexpr CharT str_less[] = {'f', 'o', 'a'};
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+  static constexpr CharT str_greater[] = {'f', 'o', 'z'};
+  static constexpr CharT str_bigger[] = {'f', 'o', 'o', 'o'};
+
+  /* size_type copy(charT* s, size_type n, size_type pos = 0) const;*/ {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.copy(nullptr, 0)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.copy(nullptr, 0, sv.size())),
+                       string_view::size_type>::value);
+    CHECK(sv.copy(nullptr, 0) == 0);
+    CHECK(sv.copy(nullptr, 0, sv.size()) == 0);
+    CHECK_THROWS_AS(sv.copy(nullptr, 0, sv.size() + 1), std::out_of_range);
+
+    CharT buf[3] = {'b', 'a', 'r'};
+    CHECK(sv.copy(buf, sv.npos) == sv.size());
+    CHECK(Traits::eq(buf[0], str[0]));
+    CHECK(Traits::eq(buf[1], str[1]));
+    CHECK(Traits::eq(buf[2], str[2]));
+
+    buf[0] = 'b', buf[1] = 'a', buf[2] = 'r';
+    CHECK(sv.copy(buf, sv.npos, 0) == sv.size());
+    CHECK(Traits::eq(buf[0], str[0]));
+    CHECK(Traits::eq(buf[1], str[1]));
+    CHECK(Traits::eq(buf[2], str[2]));
+
+    buf[0] = 'b', buf[1] = 'a', buf[2] = 'r';
+    CHECK(sv.copy(buf, sv.npos, 1) == sv.size() - 1);
+    CHECK(Traits::eq(buf[0], str[1]));
+    CHECK(Traits::eq(buf[1], str[2]));
+    CHECK(Traits::eq(buf[2], 'r'));
+
+    buf[0] = 'b', buf[1] = 'a', buf[2] = 'r';
+    CHECK(sv.copy(buf, sv.size() - 1, 0) == sv.size() - 1);
+    CHECK(Traits::eq(buf[0], str[0]));
+    CHECK(Traits::eq(buf[1], str[1]));
+    CHECK(Traits::eq(buf[2], 'r'));
+  }
+
+  /* constexpr basic_string_view substr(size_type pos = 0, size_type n = npos)
+      const; */
+  {
+    constexpr string_view sv(str, countof(str));
+    CHECK(std::is_same<decltype(sv.substr()), string_view>::value);
+    CHECK(std::is_same<decltype(sv.substr(0)), string_view>::value);
+    CHECK(std::is_same<decltype(sv.substr(0, sv.npos)), string_view>::value);
+    CHECK_THROWS_AS(sv.substr(sv.size() + 1, sv.npos), std::out_of_range);
+
+    constexpr string_view sub0 = sv.substr();
+    CHECK(sub0.data() == sv.data());
+    CHECK(sub0.size() == sv.size());
+
+    constexpr string_view sub1 = sv.substr(0);
+    CHECK(sub1.data() == sv.data());
+    CHECK(sub1.size() == sv.size());
+
+    constexpr string_view sub2 = sv.substr(0, sv.npos);
+    CHECK(sub2.data() == sv.data());
+    CHECK(sub2.size() == sv.size());
+
+    /*constexpr*/ string_view sub3 = sv.substr(1, sv.npos); // confuses gcc
+    CHECK(sub3.data() == sv.data() + 1);
+    CHECK(sub3.size() == sv.size() - 1);
+
+    constexpr string_view sub4 = sv.substr(sv.size(), sv.npos);
+    CHECK(sub4.data() == sv.data() + sv.size());
+    CHECK(sub4.size() == 0u);
+
+    constexpr string_view sub5 = sv.substr(0, sv.size() - 1);
+    CHECK(sub5.data() == sv.data());
+    CHECK(sub5.size() == sv.size() - 1);
+
+    constexpr string_view sub6 = sv.substr(0, 1);
+    CHECK(sub6.data() == sv.data());
+    CHECK(sub6.size() == 1);
+  }
+
+  /* constexpr int compare(basic_string_view str) const noexcept; */
+  /* constexpr int compare(const charT* s) const; */
+  {
+    static constexpr CharT strx[] = {'f', 'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv.compare(x)), int>::value);
+    CHECK(noexcept(sv.compare(x)));
+    CHECK(sv.compare(x) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare = sv.compare(x);
+    (void)compare;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK(smaller.compare(sv) < 0);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK(less.compare(sv) < 0);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK(greater.compare(sv) > 0);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK(bigger.compare(sv) > 0);
+
+    CHECK(std::is_same<decltype(sv.compare(strx)), int>::value);
+    CHECK(sv.compare(strx) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare_sz = sv.compare(strx);
+    (void)compare_sz;
+
+    CHECK(smaller.compare(strx) < 0);
+    CHECK(less.compare(strx) < 0);
+    CHECK(greater.compare(strx) > 0);
+    CHECK(bigger.compare(strx) > 0);
+  }
+
+  /* constexpr int compare(size_type pos1, size_type n1, basic_string_view str)
+         const; */
+  /* constexpr int compare(size_type pos1, size_type n1, const charT* s) const;
+   */
+  {
+    static constexpr CharT strx[] = {'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv.compare(1, 2, x)), int>::value);
+    CHECK(sv.compare(1, 2, x) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare = sv.compare(1, 2, x);
+    (void)compare;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK(smaller.compare(1, 1, x) < 0);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK(less.compare(1, 2, x) < 0);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK(greater.compare(1, 2, x) > 0);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK(bigger.compare(1, 3, x) > 0);
+
+    CHECK(std::is_same<decltype(sv.compare(1, 2, strx)), int>::value);
+    CHECK(sv.compare(1, 2, strx) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare_sz = sv.compare(1, 2, strx);
+    (void)compare_sz;
+
+    CHECK(smaller.compare(1, 1, strx) < 0);
+    CHECK(less.compare(1, 2, strx) < 0);
+    CHECK(greater.compare(1, 2, strx) > 0);
+    CHECK(bigger.compare(1, 3, strx) > 0);
+  }
+
+  /* constexpr int compare(size_type pos1, size_type n1, basic_string_view str,
+         size_type pos2, size_type n2) const; */
+  /* constexpr int compare(
+         size_type pos1, size_type n1, const charT* s, size_type n2) const; */
+  {
+    static constexpr CharT strx[] = {'b', 'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv.compare(1, 2, x, 1, 2)), int>::value);
+    CHECK(sv.compare(1, 2, x, 1, 2) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare = sv.compare(1, 2, x, 1, 2);
+    (void)compare;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK(smaller.compare(1, 1, sv, 1, 2) < 0);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK(less.compare(1, 2, sv, 1, 2) < 0);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK(greater.compare(1, 2, sv, 1, 2) > 0);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK(bigger.compare(1, 3, sv, 1, 2) > 0);
+
+    CHECK(std::is_same<decltype(sv.compare(1, 2, strx, 1, 2)), int>::value);
+    CHECK(sv.compare(1, 2, strx, 1, 2) == 0);
+    SLB_CONSTEXPR_CHAR_TRAITS int compare_sz = sv.compare(1, 2, strx, 1, 2);
+    (void)compare_sz;
+
+    CHECK(smaller.compare(1, 1, strx, 1, 2) < 0);
+    CHECK(less.compare(1, 2, strx, 1, 2) < 0);
+    CHECK(greater.compare(1, 2, strx, 1, 2) > 0);
+    CHECK(bigger.compare(1, 3, strx, 1, 2) > 0);
+  }
+
+  /* constexpr bool starts_with(basic_string_view x) const noexcept; */
+  /* constexpr bool starts_with(const charT* x) const; */
+  {
+    static constexpr CharT strx[] = {'f', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv.starts_with(x)), bool>::value);
+    CHECK(noexcept(sv.starts_with(x)));
+    CHECK(sv.starts_with(x));
+    SLB_CONSTEXPR_CHAR_TRAITS bool starts_with = sv.starts_with(x);
+    (void)starts_with;
+
+    CHECK_FALSE(sv.starts_with(string_view(str + 1, countof(str) - 1)));
+    CHECK(sv.starts_with(string_view()));
+
+    CHECK(std::is_same<decltype(sv.starts_with(strx)), bool>::value);
+    CHECK(sv.starts_with(strx));
+    SLB_CONSTEXPR_CHAR_TRAITS bool starts_with_sz = sv.starts_with(strx);
+    (void)starts_with_sz;
+
+    static constexpr CharT strnx[] = {'o', 'o', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+    CHECK_FALSE(sv.starts_with(strnx));
+    CHECK(sv.starts_with(stre));
+  }
+
+  /* constexpr bool starts_with(charT x) const noexcept; */
+  {
+    constexpr string_view sv(str, countof(str));
+    constexpr CharT chx = 'f';
+    CHECK(std::is_same<decltype(sv.starts_with(chx)), bool>::value);
+    CHECK(noexcept(sv.starts_with(chx)));
+    CHECK(sv.starts_with(chx));
+    SLB_CONSTEXPR_CHAR_TRAITS bool starts_with = sv.starts_with(chx);
+    (void)starts_with;
+
+    CHECK_FALSE(sv.starts_with('o'));
+  }
+
+  /* constexpr bool ends_with(basic_string_view x) const noexcept; */
+  /* constexpr bool ends_with(const charT* x) const; */
+  {
+    static constexpr CharT strx[] = {'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv.ends_with(x)), bool>::value);
+    CHECK(noexcept(sv.ends_with(x)));
+    CHECK(sv.ends_with(x));
+    SLB_CONSTEXPR_CHAR_TRAITS bool ends_with = sv.ends_with(x);
+    (void)ends_with;
+
+    CHECK_FALSE(sv.ends_with(string_view(str, countof(str) - 1)));
+    CHECK(sv.ends_with(string_view()));
+
+    CHECK(std::is_same<decltype(sv.ends_with(strx)), bool>::value);
+    CHECK(sv.ends_with(strx));
+    SLB_CONSTEXPR_CHAR_TRAITS bool ends_with_sz = sv.ends_with(strx);
+    (void)ends_with_sz;
+
+    static constexpr CharT strnx[] = {'f', 'o', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+    CHECK_FALSE(sv.ends_with(strnx));
+    CHECK(sv.ends_with(stre));
+  }
+
+  /* constexpr bool ends_with(charT x) const noexcept; */
+  {
+    constexpr string_view sv(str, countof(str));
+    constexpr CharT chx = 'o';
+    CHECK(std::is_same<decltype(sv.ends_with(chx)), bool>::value);
+    CHECK(noexcept(sv.ends_with(chx)));
+    CHECK(sv.ends_with(chx));
+    SLB_CONSTEXPR_CHAR_TRAITS bool ends_with = sv.ends_with(chx);
+    (void)ends_with;
+
+    CHECK_FALSE(sv.ends_with('f'));
+  }
+}
+
+// [string.view.find], searching
+TEST_CASE(SLB_INSTANTIATION "(searching)", "[string.view.find]") {
+  static constexpr CharT str[] = {'f', 'f', 'f', 'o', 'o', '\0', 'b', 'a', 'r'};
+  static constexpr CharT rstr[] = {
+      'r', 'a', 'b', '\0', 'o', 'o', 'f', 'f', 'f'};
+
+  /* constexpr size_type find(basic_string_view s, size_type pos = 0) const
+        noexcept; */
+  /* constexpr size_type find(const charT* s, size_type pos = 0) const; */
+  /* constexpr size_type find(const charT* s, size_type pos, size_type n)
+        const; */
+  {
+    static constexpr CharT strx[] = {'f', 'f', 'o', 'o', '\0', 'b'};
+    static constexpr CharT strnx[] = {'b', 'a', 'z', '\0'};
+    static constexpr CharT stro[] = {'o', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx));
+    CHECK(std::is_same<decltype(sv.find(x)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find(x, 0)), string_view::size_type>::value);
+    CHECK(noexcept(sv.find(x)));
+    CHECK(noexcept(sv.find(x, 0)));
+    CHECK(sv.find(x) == 1);
+    CHECK(sv.find(x, 0) == 1);
+    CHECK(sv.find(x, 2) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find0 = sv.find(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find1 =
+        sv.find(x, 0);
+    (void)find0;
+    (void)find1;
+
+    constexpr string_view nx(strnx, countof(strnx) - 1);
+    constexpr string_view o(stro, countof(stro) - 1);
+    CHECK(sv.find(o, 0) == 3);
+    CHECK(sv.find(o, 4) == 4);
+    CHECK(sv.find(o, 5) == sv.npos);
+    CHECK(sv.find(nx, 0) == sv.npos);
+    CHECK(sv.find(string_view(), 0) == 0);
+
+    CHECK(std::is_same<decltype(sv.find(strx)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find(strx, 0)),
+                       string_view::size_type>::value);
+    CHECK(sv.find(strx) == 1);
+    CHECK(sv.find(strx, 0) == 1);
+    CHECK(sv.find(strx, 2) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find0_sz =
+        sv.find(strx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find1_sz =
+        sv.find(strx, 0);
+    (void)find0_sz;
+    (void)find1_sz;
+
+    CHECK(sv.find(stro, 0) == 3);
+    CHECK(sv.find(stro, 4) == 4);
+    CHECK(sv.find(stro, 5) == sv.npos);
+    CHECK(sv.find(strnx, 0) == sv.npos);
+    CHECK(sv.find(stre, 0) == 0);
+
+    CHECK(std::is_same<decltype(sv.find(strx, 0, countof(strx))),
+                       string_view::size_type>::value);
+    CHECK(sv.find(strx, 0, countof(strx)) == 1);
+    CHECK(sv.find(strx, 2, countof(strx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_sn =
+        sv.find(strx, 0, countof(strx));
+    (void)find_sn;
+
+    CHECK(sv.find(stro, 0, countof(stro)) == 4);
+    CHECK(sv.find(stro, 5, countof(stro)) == sv.npos);
+    CHECK(sv.find(strnx, 0, countof(strnx)) == sv.npos);
+    CHECK(sv.find(stre, 0, 1) == 5);
+  }
+
+  /* constexpr size_type find(charT c, size_type pos = 0) const noexcept; */
+  {
+    constexpr string_view sv(str, countof(str));
+    constexpr CharT x = 'f';
+    CHECK(std::is_same<decltype(sv.find(x)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find(x, 0)), string_view::size_type>::value);
+    CHECK(noexcept(sv.find(x)));
+    CHECK(noexcept(sv.find(x, 0)));
+    CHECK(sv.find(x) == 0);
+    CHECK(sv.find(x, 0) == 0);
+    CHECK(sv.find(x, 3) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find0 = sv.find(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find1 =
+        sv.find(x, 0);
+    (void)find0;
+    (void)find1;
+
+    constexpr CharT nx = 'z';
+    constexpr CharT o = 'o';
+    CHECK(sv.find(o, 0) == 3);
+    CHECK(sv.find(o, 4) == 4);
+    CHECK(sv.find(o, 5) == sv.npos);
+    CHECK(sv.find(nx, 0) == sv.npos);
+  }
+
+  /* constexpr size_type rfind(basic_string_view s, size_type pos = npos)
+     const noexcept; */
+  /* constexpr size_type rfind(const charT* s, size_type pos = npos) const;
+   */
+  /* constexpr size_type rfind(const charT* s, size_type pos, size_type n)
+        const; */
+  {
+    static constexpr CharT rstrx[] = {'b', '\0', 'o', 'o', 'f', 'f'};
+    static constexpr CharT rstrnx[] = {'z', 'a', 'b', '\0'};
+    static constexpr CharT rstro[] = {'o', '\0'};
+    static constexpr CharT rstre[] = {'\0'};
+
+    constexpr string_view sv(rstr, countof(str));
+    constexpr string_view x(rstrx, countof(rstrx));
+    CHECK(std::is_same<decltype(sv.rfind(x)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.rfind(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.rfind(x)));
+    CHECK(noexcept(sv.rfind(x, sv.npos)));
+    CHECK(sv.rfind(x) == 2);
+    CHECK(sv.rfind(x, sv.npos) == 2);
+    CHECK(sv.rfind(x, 2) == 2);
+    CHECK(sv.rfind(x, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind0 = sv.rfind(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind1 =
+        sv.rfind(x, sv.npos);
+    (void)rfind0;
+    (void)rfind1;
+
+    constexpr string_view nx(rstrnx, countof(rstrnx) - 1);
+    constexpr string_view o(rstro, countof(rstro) - 1);
+    CHECK(sv.rfind(o, sv.npos) == 5);
+    CHECK(sv.rfind(o, 4) == 4);
+    CHECK(sv.rfind(o, 3) == sv.npos);
+    CHECK(sv.rfind(nx, sv.npos) == sv.npos);
+    CHECK(sv.rfind(string_view(), sv.npos) == 9);
+
+    CHECK(
+        std::is_same<decltype(sv.rfind(rstrx)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.rfind(rstrx, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(sv.rfind(rstrx) == 2);
+    CHECK(sv.rfind(rstrx, sv.npos) == 2);
+    CHECK(sv.rfind(rstrx, 2) == 2);
+    CHECK(sv.rfind(rstrx, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind0_sz =
+        sv.rfind(rstrx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind1_sz =
+        sv.rfind(rstrx, sv.npos);
+    (void)rfind0_sz;
+    (void)rfind1_sz;
+
+    CHECK(sv.rfind(rstro, sv.npos) == 5);
+    CHECK(sv.rfind(rstro, 4) == 4);
+    CHECK(sv.rfind(rstro, 3) == sv.npos);
+    CHECK(sv.rfind(rstrnx, sv.npos) == sv.npos);
+    CHECK(sv.rfind(rstre, sv.npos) == 9);
+
+    CHECK(std::is_same<decltype(sv.rfind(rstrx, sv.npos, countof(rstrx))),
+                       string_view::size_type>::value);
+    CHECK(sv.rfind(rstrx, sv.npos, countof(rstrx)) == 2);
+    CHECK(sv.rfind(rstrx, 2, countof(rstrx)) == 2);
+    CHECK(sv.rfind(rstrx, 1, countof(rstrx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind_sn =
+        sv.rfind(rstrx, sv.npos, countof(rstrx));
+    (void)rfind_sn;
+
+    CHECK(sv.rfind(rstro, sv.npos, countof(rstro)) == sv.npos);
+    CHECK(sv.rfind(rstrnx, sv.npos, countof(rstrnx)) == sv.npos);
+    CHECK(sv.rfind(rstre, sv.npos, 1) == 3);
+  }
+
+  /* constexpr size_type rfind(charT c, size_type pos = npos) const
+  noexcept;
+  /*/
+  {
+    constexpr string_view sv(rstr, countof(rstr));
+    constexpr CharT x = 'f';
+    CHECK(std::is_same<decltype(sv.rfind(x)), string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.rfind(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.rfind(x)));
+    CHECK(noexcept(sv.rfind(x, sv.npos)));
+    CHECK(sv.rfind(x) == 8);
+    CHECK(sv.rfind(x, sv.npos) == 8);
+    CHECK(sv.rfind(x, 6) == 6);
+    CHECK(sv.rfind(x, 5) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind0 = sv.rfind(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type rfind1 =
+        sv.rfind(x, sv.npos);
+    (void)rfind0;
+    (void)rfind1;
+
+    constexpr CharT nx = 'z';
+    constexpr CharT o = 'o';
+    CHECK(sv.rfind(o, sv.npos) == 5);
+    CHECK(sv.rfind(o, 4) == 4);
+    CHECK(sv.rfind(o, 3) == sv.npos);
+    CHECK(sv.rfind(nx, sv.npos) == sv.npos);
+  }
+
+  /* constexpr size_type find_first_of(basic_string_view s, size_type pos =
+     0) const noexcept; */
+  /* constexpr size_type find_first_of(const charT* s, size_type pos = 0)
+         const; */
+  /* constexpr size_type find_first_of(const charT* s, size_type pos,
+     size_type n) const; */
+  {
+    static constexpr CharT strx[] = {'f', 'b', '\0'};
+    static constexpr CharT strnx[] = {'x', 'y', 'z', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx));
+    CHECK(std::is_same<decltype(sv.find_first_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_of(x, 0)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_first_of(x)));
+    CHECK(noexcept(sv.find_first_of(x, 0)));
+    CHECK(sv.find_first_of(x) == 0);
+    CHECK(sv.find_first_of(x, 0) == 0);
+    CHECK(sv.find_first_of(x, 3) == 5);
+    CHECK(sv.find_first_of(x, 7) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of0 =
+        sv.find_first_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of1 =
+        sv.find_first_of(x, 0);
+    (void)find_first_of0;
+    (void)find_first_of1;
+
+    constexpr string_view nx(strnx, countof(strnx) - 1);
+    CHECK(sv.find_first_of(nx, 0) == sv.npos);
+    CHECK(sv.find_first_of(string_view(), 0) == sv.npos);
+
+    CHECK(std::is_same<decltype(sv.find_first_of(strx)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_of(strx, 0)),
+                       string_view::size_type>::value);
+    CHECK(sv.find_first_of(strx) == 0);
+    CHECK(sv.find_first_of(strx, 0) == 0);
+    CHECK(sv.find_first_of(strx, 3) == 6);
+    CHECK(sv.find_first_of(strx, 7) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of0_sz =
+        sv.find_first_of(strx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of1_sz =
+        sv.find_first_of(strx, 0);
+    (void)find_first_of0_sz;
+    (void)find_first_of1_sz;
+
+    CHECK(sv.find_first_of(strnx, 0) == sv.npos);
+    CHECK(sv.find_first_of(stre, 0) == sv.npos);
+
+    CHECK(std::is_same<decltype(sv.find_first_of(strx, 0, countof(strx))),
+                       string_view::size_type>::value);
+    CHECK(sv.find_first_of(strx, 0, countof(strx)) == 0);
+    CHECK(sv.find_first_of(strx, 3, countof(strx)) == 5);
+    CHECK(sv.find_first_of(strx, 7, countof(strx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of_sn =
+        sv.find_first_of(strx, 0, countof(strx));
+    (void)find_first_of_sn;
+
+    CHECK(sv.find_first_of(strnx, 0, countof(strnx)) == 5);
+    CHECK(sv.find_first_of(stre, 0, 1) == 5);
+  }
+
+  /* constexpr size_type find_first_of(charT c, size_type pos = 0) const
+        noexcept; */
+  {
+    constexpr string_view sv(str, countof(str));
+    constexpr CharT x = 'f';
+    CHECK(std::is_same<decltype(sv.find_first_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_of(x, 0)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_first_of(x)));
+    CHECK(noexcept(sv.find_first_of(x, 0)));
+    CHECK(sv.find_first_of(x) == 0);
+    CHECK(sv.find_first_of(x, 0) == 0);
+    CHECK(sv.find_first_of(x, 3) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of0 =
+        sv.find_first_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_of1 =
+        sv.find_first_of(x, 0);
+    (void)find_first_of0;
+    (void)find_first_of1;
+
+    constexpr CharT nx = 'z';
+    CHECK(sv.find_first_of(nx, 0) == sv.npos);
+  }
+
+  /* constexpr size_type find_last_of(basic_string_view s, size_type pos =
+     npos) const noexcept; */
+  /* constexpr size_type find_last_of(const charT* s, size_type pos = npos)
+        const; */
+  /* constexpr size_type find_last_of(const charT* s, size_type pos,
+     size_type n) const; */
+  {
+    static constexpr CharT strx[] = {'f', 'b', '\0'};
+    static constexpr CharT strnx[] = {'x', 'y', 'z', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+
+    constexpr string_view sv(rstr, countof(rstr));
+    constexpr string_view x(strx, countof(strx));
+    CHECK(std::is_same<decltype(sv.find_last_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_of(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_last_of(x)));
+    CHECK(noexcept(sv.find_last_of(x, sv.npos)));
+    CHECK(sv.find_last_of(x) == 8);
+    CHECK(sv.find_last_of(x, sv.npos) == 8);
+    CHECK(sv.find_last_of(x, 5) == 3);
+    CHECK(sv.find_last_of(x, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of0 =
+        sv.find_last_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of1 =
+        sv.find_last_of(x, sv.npos);
+    (void)find_last_of0;
+    (void)find_last_of1;
+
+    constexpr string_view nx(strnx, countof(strnx) - 1);
+    CHECK(sv.find_last_of(nx, sv.npos) == sv.npos);
+    CHECK(sv.find_last_of(string_view(), sv.npos) == sv.npos);
+
+    CHECK(std::is_same<decltype(sv.find_last_of(strx)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_of(strx, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(sv.find_last_of(strx) == 8);
+    CHECK(sv.find_last_of(strx, sv.npos) == 8);
+    CHECK(sv.find_last_of(strx, 5) == 2);
+    CHECK(sv.find_last_of(strx, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of0_sz =
+        sv.find_last_of(strx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of1_sz =
+        sv.find_last_of(strx, sv.npos);
+    (void)find_last_of0_sz;
+    (void)find_last_of1_sz;
+
+    CHECK(sv.find_last_of(strnx, sv.npos) == sv.npos);
+    CHECK(sv.find_last_of(stre, sv.npos) == sv.npos);
+
+    CHECK(std::is_same<decltype(sv.find_last_of(strx, sv.npos, countof(strx))),
+                       string_view::size_type>::value);
+    CHECK(sv.find_last_of(strx, sv.npos, countof(strx)) == 8);
+    CHECK(sv.find_last_of(strx, 5, countof(strx)) == 3);
+    CHECK(sv.find_last_of(strx, 1, countof(strx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of_sn =
+        sv.find_last_of(strx, sv.npos, countof(strx));
+    (void)find_last_of_sn;
+
+    CHECK(sv.find_last_of(strnx, sv.npos, countof(strnx)) == 3);
+    CHECK(sv.find_last_of(stre, sv.npos, 1) == 3);
+  }
+
+  /* constexpr size_type find_last_of(charT c, size_type pos = npos) const
+         noexcept; */
+  {
+    constexpr string_view sv(rstr, countof(rstr));
+    constexpr CharT x = 'f';
+    CHECK(std::is_same<decltype(sv.find_last_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_of(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_last_of(x)));
+    CHECK(noexcept(sv.find_last_of(x, sv.npos)));
+    CHECK(sv.find_last_of(x) == 8);
+    CHECK(sv.find_last_of(x, sv.npos) == 8);
+    CHECK(sv.find_last_of(x, 5) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of0 =
+        sv.find_last_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_of1 =
+        sv.find_last_of(x, sv.npos);
+    (void)find_last_of0;
+    (void)find_last_of1;
+
+    constexpr CharT nx = 'z';
+    CHECK(sv.find_last_of(nx, sv.npos) == sv.npos);
+  }
+
+  /* constexpr size_type find_first_not_of(basic_string_view s, size_type
+     pos = 0) const noexcept; */
+  /* constexpr size_type find_first_not_of(const charT* s, size_type pos =
+     0) const; */
+  /* constexpr size_type find_first_not_of(const charT* s, size_type pos,
+         size_type n) const; */
+  {
+    static constexpr CharT strx[] = {'a', 'r', 'z', '\0'};
+    static constexpr CharT strnx[] = {'f', 'b', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx));
+    CHECK(std::is_same<decltype(sv.find_first_not_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_not_of(x, 0)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_first_not_of(x)));
+    CHECK(noexcept(sv.find_first_not_of(x, 0)));
+    CHECK(sv.find_first_not_of(x) == 0);
+    CHECK(sv.find_first_not_of(x, 0) == 0);
+    CHECK(sv.find_first_not_of(x, 5) == 6);
+    CHECK(sv.find_first_not_of(x, 7) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_not_of0 =
+        sv.find_first_not_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_not_of1 =
+        sv.find_first_not_of(x, 0);
+    (void)find_first_not_of0;
+    (void)find_first_not_of1;
+
+    constexpr string_view nx(strnx, countof(strnx) - 1);
+    CHECK(sv.find_first_not_of(nx, 0) == 3);
+    CHECK(sv.find_first_not_of(nx, 5) == 5);
+    CHECK(sv.find_first_not_of(nx, 6) == 7);
+    CHECK(sv.find_first_not_of(string_view(), 0) == 0);
+
+    CHECK(std::is_same<decltype(sv.find_first_not_of(strx)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_not_of(strx, 0)),
+                       string_view::size_type>::value);
+    CHECK(sv.find_first_not_of(strx) == 0);
+    CHECK(sv.find_first_not_of(strx, 0) == 0);
+    CHECK(sv.find_first_not_of(strx, 5) == 5);
+    CHECK(sv.find_first_not_of(strx, 6) == 6);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type
+        find_first_not_of0_sz = sv.find_first_not_of(strx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type
+        find_first_not_of1_sz = sv.find_first_not_of(strx, 0);
+    (void)find_first_not_of0_sz;
+    (void)find_first_not_of1_sz;
+
+    CHECK(sv.find_first_not_of(strnx, 0) == 3);
+    CHECK(sv.find_first_not_of(strnx, 5) == 5);
+    CHECK(sv.find_first_not_of(strnx, 6) == 7);
+    CHECK(sv.find_first_not_of(stre, 0) == 0);
+
+    CHECK(std::is_same<decltype(sv.find_first_not_of(strx, 0, countof(strx))),
+                       string_view::size_type>::value);
+    CHECK(sv.find_first_not_of(strx, 0, countof(strx)) == 0);
+    CHECK(sv.find_first_not_of(strx, 5, countof(strx)) == 6);
+    CHECK(sv.find_first_not_of(strx, 7, countof(strx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type
+        find_first_not_of_sn = sv.find_first_not_of(strx, 0, countof(strx));
+    (void)find_first_not_of_sn;
+
+    CHECK(sv.find_first_not_of(strnx, 0, countof(strnx)) == 3);
+    CHECK(sv.find_first_not_of(strnx, 5, countof(strnx)) == 7);
+    CHECK(sv.find_first_not_of(stre, 0, 1) == 0);
+  }
+
+  /* constexpr size_type find_first_not_of(charT c, size_type pos = 0) const
+         noexcept; */
+  {
+    constexpr string_view sv(str, countof(str));
+    constexpr CharT x = 'z';
+    CHECK(std::is_same<decltype(sv.find_first_not_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_first_not_of(x, 0)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_first_not_of(x)));
+    CHECK(noexcept(sv.find_first_not_of(x, 0)));
+    CHECK(sv.find_first_not_of(x) == 0);
+    CHECK(sv.find_first_not_of(x, 0) == 0);
+    CHECK(sv.find_first_not_of(x, 3) == 3);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_not_of0 =
+        sv.find_first_not_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_first_not_of1 =
+        sv.find_first_not_of(x, 0);
+    (void)find_first_not_of0;
+    (void)find_first_not_of1;
+
+    constexpr CharT nx = 'f';
+    CHECK(sv.find_first_not_of(nx, 0) == 3);
+  }
+
+  /* co nstexpr size_type find_last_not_of(basic_string_view s, size_type
+     pos = npos) const noexcept; */
+  /* constexpr size_type find_last_not_of(const charT* s, size_type pos =
+     npos) const; */
+  /* constexpr size_type find_last_not_of(const charT* s, size_type pos,
+         size_type n) const; */
+  {
+    static constexpr CharT strx[] = {'a', 'r', 'z', '\0'};
+    static constexpr CharT strnx[] = {'f', 'b', '\0'};
+    static constexpr CharT stre[] = {'\0'};
+
+    constexpr string_view sv(rstr, countof(rstr));
+    constexpr string_view x(strx, countof(strx));
+    CHECK(std::is_same<decltype(sv.find_last_not_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_not_of(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_last_not_of(x)));
+    CHECK(noexcept(sv.find_last_not_of(x, sv.npos)));
+    CHECK(sv.find_last_not_of(x) == 8);
+    CHECK(sv.find_last_not_of(x, sv.npos) == 8);
+    CHECK(sv.find_last_not_of(x, 3) == 2);
+    CHECK(sv.find_last_not_of(x, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_not_of0 =
+        sv.find_last_not_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_not_of1 =
+        sv.find_last_not_of(x, sv.npos);
+    (void)find_last_not_of0;
+    (void)find_last_not_of1;
+
+    constexpr string_view nx(strnx, countof(strnx) - 1);
+    CHECK(sv.find_last_not_of(nx, sv.npos) == 5);
+    CHECK(sv.find_last_not_of(nx, 3) == 3);
+    CHECK(sv.find_last_not_of(nx, 2) == 1);
+    CHECK(sv.find_last_not_of(string_view(), sv.npos) == 8);
+
+    CHECK(std::is_same<decltype(sv.find_last_not_of(strx)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_not_of(strx, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(sv.find_last_not_of(strx) == 8);
+    CHECK(sv.find_last_not_of(strx, sv.npos) == 8);
+    CHECK(sv.find_last_not_of(strx, 3) == 3);
+    CHECK(sv.find_last_not_of(strx, 1) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type
+        find_last_not_of0_sz = sv.find_last_not_of(strx);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type
+        find_last_not_of1_sz = sv.find_last_not_of(strx, sv.npos);
+    (void)find_last_not_of0_sz;
+    (void)find_last_not_of1_sz;
+
+    CHECK(sv.find_last_not_of(strnx, sv.npos) == 5);
+    CHECK(sv.find_last_not_of(strnx, 3) == 3);
+    CHECK(sv.find_last_not_of(strnx, 2) == 1);
+    CHECK(sv.find_last_not_of(stre, sv.npos) == 8);
+
+    CHECK(std::is_same<decltype(
+                           sv.find_last_not_of(strx, sv.npos, countof(strx))),
+                       string_view::size_type>::value);
+    CHECK(sv.find_last_not_of(strx, sv.npos, countof(strx)) == 8);
+    CHECK(sv.find_last_not_of(strx, 3, countof(strx)) == 2);
+    CHECK(sv.find_last_not_of(strx, 1, countof(strx)) == sv.npos);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_not_of_sn =
+        sv.find_last_not_of(strx, sv.npos, countof(strx));
+    (void)find_last_not_of_sn;
+
+    CHECK(sv.find_last_not_of(strnx, sv.npos, countof(strnx)) == 5);
+    CHECK(sv.find_last_not_of(strnx, 3, countof(strnx)) == 1);
+    CHECK(sv.find_last_not_of(stre, sv.npos, 1) == 8);
+  }
+
+  /* constexpr size_type find_last_not_of(charT c, size_type pos = npos)
+     const noexcept; */
+  {
+    constexpr string_view sv(rstr, countof(rstr));
+    constexpr CharT x = 'z';
+    CHECK(std::is_same<decltype(sv.find_last_not_of(x)),
+                       string_view::size_type>::value);
+    CHECK(std::is_same<decltype(sv.find_last_not_of(x, sv.npos)),
+                       string_view::size_type>::value);
+    CHECK(noexcept(sv.find_last_not_of(x)));
+    CHECK(noexcept(sv.find_last_not_of(x, sv.npos)));
+    CHECK(sv.find_last_not_of(x) == 8);
+    CHECK(sv.find_last_not_of(x, sv.npos) == 8);
+    CHECK(sv.find_last_not_of(x, 5) == 5);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_not_of0 =
+        sv.find_last_not_of(x);
+    SLB_CXX14_CONSTEXPR_CHAR_TRAITS string_view::size_type find_last_not_of1 =
+        sv.find_last_not_of(x, sv.npos);
+    (void)find_last_not_of0;
+    (void)find_last_not_of1;
+
+    constexpr CharT nx = 'f';
+    CHECK(sv.find_last_not_of(nx, sv.npos) == 5);
+  }
+}
+
+// [string.view.comparison], non-member comparison functions
+TEST_CASE(SLB_INSTANTIATION "(comparison)", "[string.view.comparison]") {
+  static constexpr CharT str_smaller[] = {'f', 'o'};
+  static constexpr CharT str_less[] = {'f', 'o', 'a'};
+  static constexpr CharT str[] = {'f', 'o', 'o'};
+  static constexpr CharT strn[] = {'b', 'a', 'r'};
+  static constexpr CharT str_greater[] = {'f', 'o', 'z'};
+  static constexpr CharT str_bigger[] = {'f', 'o', 'o', 'o'};
+
+  /* template<class charT, class traits>
+       constexpr bool operator==(basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+                                 */
+  {
+    static constexpr CharT strx[] = {'f', 'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv == x), bool>::value);
+    CHECK(noexcept(sv == x));
+    CHECK(sv == x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv == x;
+    (void)compare1;
+
+    constexpr string_view equal(str, countof(str));
+    CHECK(sv == equal);
+    constexpr string_view not_equal(strn, countof(strn));
+    CHECK_FALSE(sv == not_equal);
+
+    CHECK(std::is_same<decltype(strx == sv), bool>::value);
+    CHECK(strx == sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx == sv;
+    (void)compare2;
+
+    CHECK(strx == equal);
+    CHECK_FALSE(strx == not_equal);
+
+    CHECK(std::is_same<decltype(sv == strx), bool>::value);
+    CHECK(sv == strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv == strx;
+    (void)compare3;
+
+    CHECK(equal == strx);
+    CHECK_FALSE(not_equal == strx);
+  }
+
+  /* template<class charT, class traits>
+       constexpr bool operator!=(basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+   */
+  {
+    static constexpr CharT strx[] = {'b', 'a', 'r', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv != x), bool>::value);
+    CHECK(noexcept(sv != x));
+    CHECK(sv != x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv != x;
+    (void)compare1;
+
+    constexpr string_view equal(str, countof(str));
+    CHECK_FALSE(sv != equal);
+    constexpr string_view not_equal(strn, countof(strn));
+    CHECK(sv != not_equal);
+
+    CHECK(std::is_same<decltype(strx != sv), bool>::value);
+    CHECK(strx != sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx != sv;
+    (void)compare2;
+
+    CHECK(strx != equal);
+    CHECK_FALSE(strx != not_equal);
+
+    CHECK(std::is_same<decltype(sv != strx), bool>::value);
+    CHECK(sv != strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv != strx;
+    (void)compare3;
+
+    CHECK(equal != strx);
+    CHECK_FALSE(not_equal != strx);
+  }
+
+  /* template<class charT, class traits>
+       constexpr bool operator< (basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+   */
+  {
+    static constexpr CharT strx[] = {'f', 'o', 'o', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv < x), bool>::value);
+    CHECK(noexcept(sv < x));
+    CHECK(sv < x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv < x;
+    (void)compare1;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK_FALSE(sv < smaller);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK_FALSE(sv < less);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK(sv < greater);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK(sv < bigger);
+
+    CHECK(std::is_same<decltype(strx < sv), bool>::value);
+    CHECK_FALSE(strx < sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx < sv;
+    (void)compare2;
+
+    CHECK_FALSE(strx < smaller);
+    CHECK_FALSE(strx < less);
+    CHECK(strx < greater);
+    CHECK_FALSE(strx < bigger);
+
+    CHECK(std::is_same<decltype(sv < strx), bool>::value);
+    CHECK(sv < strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv < strx;
+    (void)compare3;
+
+    CHECK(smaller < strx);
+    CHECK(less < strx);
+    CHECK_FALSE(greater < strx);
+    CHECK_FALSE(bigger < strx);
+  }
+
+  /* template<class charT, class traits>
+       constexpr bool operator> (basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+   */
+  {
+    static constexpr CharT strx[] = {'f', 'o', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv > x), bool>::value);
+    CHECK(noexcept(sv > x));
+    CHECK(sv > x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv > x;
+    (void)compare1;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK(sv > smaller);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK(sv > less);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK_FALSE(sv > greater);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK_FALSE(sv > bigger);
+
+    CHECK(std::is_same<decltype(strx > sv), bool>::value);
+    CHECK_FALSE(strx > sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx > sv;
+    (void)compare2;
+
+    CHECK_FALSE(strx > smaller);
+    CHECK_FALSE(strx > less);
+    CHECK_FALSE(strx > greater);
+    CHECK_FALSE(strx > bigger);
+
+    CHECK(std::is_same<decltype(sv > strx), bool>::value);
+    CHECK(sv > strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv > strx;
+    (void)compare3;
+
+    CHECK_FALSE(smaller > strx);
+    CHECK(less > strx);
+    CHECK(greater > strx);
+    CHECK(bigger > strx);
+  }
+
+  /* template<class charT, class traits>
+       constexpr bool operator<=(basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+   */
+  {
+    static constexpr CharT strx[] = {'f', 'o', 'z', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv <= x), bool>::value);
+    CHECK(noexcept(sv <= x));
+    CHECK(sv <= x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv <= x;
+    (void)compare1;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK_FALSE(sv <= smaller);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK_FALSE(sv <= less);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK(sv <= greater);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK(sv <= bigger);
+
+    CHECK(std::is_same<decltype(strx <= sv), bool>::value);
+    CHECK_FALSE(strx <= sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx <= sv;
+    (void)compare2;
+
+    CHECK_FALSE(strx <= smaller);
+    CHECK_FALSE(strx <= less);
+    CHECK(strx <= greater);
+    CHECK_FALSE(strx <= bigger);
+
+    CHECK(std::is_same<decltype(sv <= strx), bool>::value);
+    CHECK(sv <= strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv <= strx;
+    (void)compare3;
+
+    CHECK(smaller <= strx);
+    CHECK(less <= strx);
+    CHECK(greater <= strx);
+    CHECK(bigger <= strx);
+  }
+
+  /* template<class charT, class traits>
+       constexpr bool operator>=(basic_string_view<charT, traits> x,
+                                 basic_string_view<charT, traits> y)
+     noexcept;
+   */
+  {
+    static constexpr CharT strx[] = {'f', 'o', 'a', '\0'};
+
+    constexpr string_view sv(str, countof(str));
+    constexpr string_view x(strx, countof(strx) - 1);
+    CHECK(std::is_same<decltype(sv >= x), bool>::value);
+    CHECK(noexcept(sv >= x));
+    CHECK(sv >= x);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare1 = sv >= x;
+    (void)compare1;
+
+    constexpr string_view smaller(str_smaller, countof(str_smaller));
+    CHECK(sv >= smaller);
+    constexpr string_view less(str_less, countof(str_less));
+    CHECK(sv >= less);
+    constexpr string_view greater(str_greater, countof(str_greater));
+    CHECK_FALSE(sv >= greater);
+    constexpr string_view bigger(str_bigger, countof(str_bigger));
+    CHECK_FALSE(sv >= bigger);
+
+    CHECK(std::is_same<decltype(strx >= sv), bool>::value);
+    CHECK_FALSE(strx >= sv);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare2 = strx >= sv;
+    (void)compare2;
+
+    CHECK(strx >= smaller);
+    CHECK(strx >= less);
+    CHECK_FALSE(strx >= greater);
+    CHECK_FALSE(strx >= bigger);
+
+    CHECK(std::is_same<decltype(sv >= strx), bool>::value);
+    CHECK(sv >= strx);
+    SLB_CONSTEXPR_CHAR_TRAITS bool compare3 = sv >= strx;
+    (void)compare3;
+
+    CHECK_FALSE(smaller >= strx);
+    CHECK(less >= strx);
+    CHECK(greater >= strx);
+    CHECK(bigger >= strx);
+  }
+}
+
+#endif


### PR DESCRIPTION
Some notes:

- There is no compatibility with `std::string`, as those changes are intrusive. We should consider adding the extra conversions and functionality from the LFTS to support that non-intrusively. Similarly, we should consider the compatibility story for when `std::string_view` is available.

- Other functionality that interacts with `<string_view>`:
   - constexpr `char_traits`,
   - constexpr `reverse_iterator`,
   - enabled/disabled `hash`,
   - constexpr `swap`,
   - range access.

- User-defined literals are not conforming, for obvious reasons.
